### PR TITLE
STYLE: about/info系4ページをPageSheetLayoutに統一

### DIFF
--- a/src/app/about/contact/ContactForm.tsx
+++ b/src/app/about/contact/ContactForm.tsx
@@ -108,7 +108,7 @@ export function ContactForm() {
           <select
             id="type"
             {...register("type")}
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           >
             {(Object.keys(contactTypeLabels) as ContactType[]).map((type) => (
               <option key={type} value={type}>
@@ -129,7 +129,7 @@ export function ContactForm() {
             type="text"
             {...register("name")}
             placeholder="山田 太郎"
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
         </div>
@@ -144,7 +144,7 @@ export function ContactForm() {
             type="email"
             {...register("email")}
             placeholder="example@example.com"
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
         </div>
@@ -159,7 +159,7 @@ export function ContactForm() {
             type="tel"
             {...register("phone")}
             placeholder="090-1234-5678"
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {errors.phone && <p className="mt-1 text-sm text-red-600">{errors.phone.message}</p>}
         </div>
@@ -174,7 +174,7 @@ export function ContactForm() {
             type="text"
             {...register("subject")}
             placeholder="企画について"
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {errors.subject && <p className="mt-1 text-sm text-red-600">{errors.subject.message}</p>}
         </div>
@@ -189,7 +189,7 @@ export function ContactForm() {
             {...register("message")}
             rows={8}
             placeholder="お問い合わせ内容を入力してください（10文字以上）"
-            className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-3 text-gray-900 placeholder-white/50 transition-colors focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
+            className="w-full rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-900 placeholder-gray-400 transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
           {errors.message && <p className="mt-1 text-sm text-red-600">{errors.message.message}</p>}
         </div>
@@ -200,10 +200,10 @@ export function ContactForm() {
             <input
               type="checkbox"
               {...register("agreeToPrivacyPolicy")}
-              className="mt-1 h-4 w-4 rounded border-gray-200/30 text-primary focus:ring-2 focus:ring-white/20"
+              className="mt-1 h-4 w-4 rounded border-gray-300 text-primary focus:ring-2 focus:ring-primary/20"
             />
             <span className="text-sm text-gray-900/90">
-              <Link href="/about/privacy" className="text-primary-light hover:underline">
+              <Link href="/about/privacy" className="text-primary hover:underline">
                 プライバシーポリシー
               </Link>
               に同意する <span className="text-red-500">*</span>
@@ -219,7 +219,7 @@ export function ContactForm() {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-6 py-4 font-semibold text-primary transition-all hover:bg-white/90 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-4 font-semibold text-white transition-all hover:bg-primary-500 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? (
               <>
@@ -236,7 +236,7 @@ export function ContactForm() {
         </div>
 
         {/* 注意事項 */}
-        <div className="rounded-lg bg-white/10 p-4">
+        <div className="rounded-lg bg-gray-50 p-4">
           <p className="text-sm text-gray-900/90">
             <span className="text-red-500">*</span> は必須項目です。
             <br />

--- a/src/app/about/contact/page.tsx
+++ b/src/app/about/contact/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Mail, Phone, MapPin } from "lucide-react";
 import { ContactForm } from "./ContactForm";
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
 
 /**
  * メタデータ
@@ -22,50 +24,37 @@ export const metadata: Metadata = {
  */
 export default function ContactPage() {
   return (
-    <div className="min-h-screen bg-secondary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-center gap-3">
-            <Mail className="h-10 w-10 md:h-12 md:w-12" />
-            <h1 className="text-4xl font-bold md:text-5xl">お問い合わせ</h1>
-          </div>
-          <p className="mt-4 text-center text-lg opacity-90">
-            第97回 世田谷祭に関するご質問・ご相談
-          </p>
-        </div>
-      </div>
-
-      <div className="container mx-auto px-4 py-12">
+    <PageSheetLayout hero={pageHeroes.contact}>
+      <div className="mx-auto max-w-4xl space-y-12">
         {/* お問い合わせ種別説明 */}
-        <section className="mx-auto mb-12 max-w-4xl">
+        <section>
           <div className="grid gap-6 md:grid-cols-3">
-            <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm">
               <div className="mb-3 flex items-center gap-2">
                 <Mail className="h-5 w-5 text-blue-500" />
                 <h3 className="font-bold text-gray-900">一般・来場者向け</h3>
               </div>
-              <p className="text-sm text-gray-900/90">
+              <p className="text-sm text-gray-700">
                 企画内容、開催時間、会場案内など、来場に関するお問い合わせ
               </p>
             </div>
 
-            <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm">
               <div className="mb-3 flex items-center gap-2">
                 <Phone className="h-5 w-5 text-green-500" />
                 <h3 className="font-bold text-gray-900">取材・メディア向け</h3>
               </div>
-              <p className="text-sm text-gray-900/90">
+              <p className="text-sm text-gray-700">
                 取材申し込み、プレスリリース、メディア掲載に関するお問い合わせ
               </p>
             </div>
 
-            <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm">
               <div className="mb-3 flex items-center gap-2">
                 <MapPin className="h-5 w-5 text-orange-500" />
                 <h3 className="font-bold text-gray-900">落とし物</h3>
               </div>
-              <p className="text-sm text-gray-900/90">
+              <p className="text-sm text-gray-700">
                 世田谷祭会場で紛失された物品に関するお問い合わせ
               </p>
             </div>
@@ -73,14 +62,14 @@ export default function ContactPage() {
         </section>
 
         {/* お問い合わせフォーム */}
-        <section className="mx-auto mb-12 max-w-4xl rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
           <h2 className="mb-6 text-2xl font-bold text-gray-900">お問い合わせフォーム</h2>
 
           <ContactForm />
         </section>
 
         {/* よくある質問へのリンク */}
-        <section className="mx-auto max-w-4xl rounded-lg border border-blue-200 bg-blue-50 p-6">
+        <section className="rounded-lg border border-blue-200 bg-blue-50 p-6">
           <div className="flex items-start gap-3">
             <Mail className="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600" />
             <div>
@@ -96,6 +85,6 @@ export default function ContactPage() {
           </div>
         </section>
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }

--- a/src/app/about/privacy/page.tsx
+++ b/src/app/about/privacy/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Shield, Info, Lock, Users, Cookie, Mail, FileText, Copyright } from "lucide-react";
 import { privacyPolicyConfig } from "@/data/privacy";
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
 
 /**
  * メタデータ
@@ -23,191 +25,174 @@ export const metadata: Metadata = {
  */
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-screen bg-secondary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-center gap-3">
-            <Shield className="h-10 w-10 md:h-12 md:w-12" />
-            <h1 className="text-4xl font-bold md:text-5xl">プライバシーポリシー</h1>
+    <PageSheetLayout hero={pageHeroes.privacy}>
+      <div className="mx-auto max-w-4xl space-y-12">
+        {/* 基本情報 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Info className="h-6 w-6 text-primary" />
+            <h2 className="text-2xl font-bold text-gray-900">基本情報</h2>
           </div>
-          <p className="mt-4 text-center text-lg opacity-90">個人情報保護方針</p>
-        </div>
-      </div>
-
-      <div className="container mx-auto px-4 py-12">
-        <div className="mx-auto max-w-4xl space-y-12">
-          {/* 基本情報 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Info className="h-6 w-6 text-primary" />
-              <h2 className="text-2xl font-bold text-gray-900">基本情報</h2>
-            </div>
-            <div className="space-y-3">
-              <p className="text-gray-900/90">
-                {privacyPolicyConfig.info.organizationName}
-                （以下「当委員会」）は、お客様の個人情報保護の重要性について認識し、個人情報の保護に関する法律（個人情報保護法）を遵守すると共に、以下のプライバシーポリシーに従って、個人情報を適切に取り扱います。
+          <div className="space-y-3">
+            <p className="text-gray-700">
+              {privacyPolicyConfig.info.organizationName}
+              （以下「当委員会」）は、お客様の個人情報保護の重要性について認識し、個人情報の保護に関する法律（個人情報保護法）を遵守すると共に、以下のプライバシーポリシーに従って、個人情報を適切に取り扱います。
+            </p>
+            <div className="mt-4 rounded-lg bg-gray-100 p-4">
+              <p className="text-sm font-semibold text-gray-600">最終更新日</p>
+              <p className="text-lg font-bold text-gray-900">
+                {privacyPolicyConfig.info.updateDate}
               </p>
-              <div className="mt-4 rounded-lg bg-white/10 p-4">
-                <p className="text-sm font-semibold text-gray-900/80">最終更新日</p>
-                <p className="text-lg font-bold text-gray-900">
-                  {privacyPolicyConfig.info.updateDate}
-                </p>
+            </div>
+          </div>
+        </section>
+
+        {/* 個人情報の利用目的 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <FileText className="h-6 w-6 text-blue-500" />
+            <h2 className="text-2xl font-bold text-gray-900">個人情報の利用目的</h2>
+          </div>
+          <p className="mb-4 text-gray-700">
+            当委員会は、お客様からお預かりした個人情報を以下の目的で利用いたします。
+          </p>
+          <ul className="space-y-2">
+            {privacyPolicyConfig.purposes.map((purpose, index) => (
+              <li key={index} className="flex items-start gap-2 text-gray-700">
+                <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500"></span>
+                <span>{purpose}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* 収集する情報 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Users className="h-6 w-6 text-green-500" />
+            <h2 className="text-2xl font-bold text-gray-900">収集する情報</h2>
+          </div>
+          <p className="mb-4 text-gray-700">当サイトでは、以下の情報を収集する場合があります。</p>
+          <div className="grid gap-3 md:grid-cols-2">
+            {privacyPolicyConfig.collectedInfo.map((info, index) => (
+              <div
+                key={index}
+                className="rounded-lg border border-gray-200 bg-gray-100 p-4 text-gray-700"
+              >
+                {info}
               </div>
-            </div>
-          </section>
+            ))}
+          </div>
+        </section>
 
-          {/* 個人情報の利用目的 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <FileText className="h-6 w-6 text-blue-500" />
-              <h2 className="text-2xl font-bold text-gray-900">個人情報の利用目的</h2>
-            </div>
-            <p className="mb-4 text-gray-900/90">
-              当委員会は、お客様からお預かりした個人情報を以下の目的で利用いたします。
-            </p>
-            <ul className="space-y-2">
-              {privacyPolicyConfig.purposes.map((purpose, index) => (
-                <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500"></span>
-                  <span>{purpose}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
+        {/* セキュリティ */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Lock className="h-6 w-6 text-orange-500" />
+            <h2 className="text-2xl font-bold text-gray-900">セキュリティ</h2>
+          </div>
+          <p className="text-gray-700">{privacyPolicyConfig.security.description}</p>
+        </section>
 
-          {/* 収集する情報 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Users className="h-6 w-6 text-green-500" />
-              <h2 className="text-2xl font-bold text-gray-900">収集する情報</h2>
-            </div>
-            <p className="mb-4 text-gray-900/90">
-              当サイトでは、以下の情報を収集する場合があります。
-            </p>
-            <div className="grid gap-3 md:grid-cols-2">
-              {privacyPolicyConfig.collectedInfo.map((info, index) => (
-                <div
-                  key={index}
-                  className="rounded-lg border border-gray-200/20 bg-white/10 p-4 text-gray-900/90"
-                >
-                  {info}
-                </div>
-              ))}
-            </div>
-          </section>
+        {/* 第三者提供 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Users className="h-6 w-6 text-purple-500" />
+            <h2 className="text-2xl font-bold text-gray-900">第三者への提供</h2>
+          </div>
+          <p className="mb-4 font-semibold text-gray-900">
+            {privacyPolicyConfig.thirdParty.policy}
+          </p>
+          <p className="mb-2 text-sm text-gray-700">ただし、以下の場合を除きます。</p>
+          <ul className="space-y-2">
+            {privacyPolicyConfig.thirdParty.exceptions.map((exception, index) => (
+              <li key={index} className="flex items-start gap-2 text-gray-700">
+                <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-purple-500"></span>
+                <span>{exception}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-          {/* セキュリティ */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Lock className="h-6 w-6 text-orange-500" />
-              <h2 className="text-2xl font-bold text-gray-900">セキュリティ</h2>
+        {/* Cookie・アクセス解析 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Cookie className="h-6 w-6 text-amber-500" />
+            <h2 className="text-2xl font-bold text-gray-900">Cookie・アクセス解析</h2>
+          </div>
+          <div className="space-y-4">
+            <p className="text-gray-700">{privacyPolicyConfig.cookies.description}</p>
+            <div className="rounded-lg bg-gray-100 p-4">
+              <p className="mb-2 text-sm font-semibold text-gray-600">使用ツール</p>
+              <p className="font-bold text-amber-700">{privacyPolicyConfig.cookies.analytics}</p>
             </div>
-            <p className="text-gray-900/90">{privacyPolicyConfig.security.description}</p>
-          </section>
+            <div>
+              <p className="mb-2 text-sm text-gray-700">{privacyPolicyConfig.cookies.optOut}</p>
+              <a
+                href={privacyPolicyConfig.cookies.optOutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 text-primary hover:underline"
+              >
+                Google Analytics オプトアウトページ
+                <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </section>
 
-          {/* 第三者提供 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Users className="h-6 w-6 text-purple-500" />
-              <h2 className="text-2xl font-bold text-gray-900">第三者への提供</h2>
-            </div>
-            <p className="mb-4 font-semibold text-gray-900">
-              {privacyPolicyConfig.thirdParty.policy}
-            </p>
-            <p className="mb-2 text-sm text-gray-900/90">ただし、以下の場合を除きます。</p>
-            <ul className="space-y-2">
-              {privacyPolicyConfig.thirdParty.exceptions.map((exception, index) => (
-                <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-purple-500"></span>
-                  <span>{exception}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
+        {/* お問い合わせ窓口 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Mail className="h-6 w-6 text-pink-500" />
+            <h2 className="text-2xl font-bold text-gray-900">お問い合わせ窓口</h2>
+          </div>
+          <p className="mb-4 text-gray-700">{privacyPolicyConfig.contact.description}</p>
+          <Link
+            href={privacyPolicyConfig.contact.url}
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 font-semibold text-white transition-all hover:bg-primary-500 hover:shadow-lg"
+          >
+            <Mail className="h-5 w-5" />
+            <span>お問い合わせフォームへ</span>
+          </Link>
+        </section>
 
-          {/* Cookie・アクセス解析 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Cookie className="h-6 w-6 text-amber-500" />
-              <h2 className="text-2xl font-bold text-gray-900">Cookie・アクセス解析</h2>
-            </div>
-            <div className="space-y-4">
-              <p className="text-gray-900/90">{privacyPolicyConfig.cookies.description}</p>
-              <div className="rounded-lg bg-white/10 p-4">
-                <p className="mb-2 text-sm font-semibold text-gray-900/90">使用ツール</p>
-                <p className="font-bold text-amber-700">{privacyPolicyConfig.cookies.analytics}</p>
-              </div>
-              <div>
-                <p className="mb-2 text-sm text-gray-900/90">
-                  {privacyPolicyConfig.cookies.optOut}
-                </p>
-                <a
-                  href={privacyPolicyConfig.cookies.optOutUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 text-primary-light hover:underline"
-                >
-                  Google Analytics オプトアウトページ
-                  <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                    />
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </section>
+        {/* 免責事項 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Info className="h-6 w-6 text-red-500" />
+            <h2 className="text-2xl font-bold text-gray-900">免責事項</h2>
+          </div>
+          <ul className="space-y-2">
+            {privacyPolicyConfig.disclaimer.map((item, index) => (
+              <li key={index} className="flex items-start gap-2 text-gray-700">
+                <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-          {/* お問い合わせ窓口 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Mail className="h-6 w-6 text-pink-500" />
-              <h2 className="text-2xl font-bold text-gray-900">お問い合わせ窓口</h2>
-            </div>
-            <p className="mb-4 text-gray-900/90">{privacyPolicyConfig.contact.description}</p>
-            <Link
-              href={privacyPolicyConfig.contact.url}
-              className="inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 font-semibold text-primary transition-all hover:bg-white/90 hover:shadow-lg"
-            >
-              <Mail className="h-5 w-5" />
-              <span>お問い合わせフォームへ</span>
-            </Link>
-          </section>
-
-          {/* 免責事項 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Info className="h-6 w-6 text-red-500" />
-              <h2 className="text-2xl font-bold text-gray-900">免責事項</h2>
-            </div>
-            <ul className="space-y-2">
-              {privacyPolicyConfig.disclaimer.map((item, index) => (
-                <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </section>
-
-          {/* 著作権 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Copyright className="h-6 w-6 text-gray-900/80" />
-              <h2 className="text-2xl font-bold text-gray-900">著作権</h2>
-            </div>
-            <p className="mb-4 text-gray-900/90">{privacyPolicyConfig.copyright.description}</p>
-            <p className="text-sm text-gray-900/80">
-              Copyright © {privacyPolicyConfig.copyright.year}{" "}
-              {privacyPolicyConfig.copyright.holder}. All Rights Reserved.
-            </p>
-          </section>
-        </div>
+        {/* 著作権 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Copyright className="h-6 w-6 text-gray-600" />
+            <h2 className="text-2xl font-bold text-gray-900">著作権</h2>
+          </div>
+          <p className="mb-4 text-gray-700">{privacyPolicyConfig.copyright.description}</p>
+          <p className="text-sm text-gray-500">
+            Copyright © {privacyPolicyConfig.copyright.year} {privacyPolicyConfig.copyright.holder}.
+            All Rights Reserved.
+          </p>
+        </section>
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }

--- a/src/app/info/faq/page.tsx
+++ b/src/app/info/faq/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-import { HelpCircle } from "lucide-react";
 import { getFAQList } from "@/lib/informations";
 import { Accordion } from "@/components/ui/Accordion";
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
 import type { AccordionItem } from "@/types/accordion";
 
 /**
@@ -37,47 +38,31 @@ export default async function FAQPage() {
   }));
 
   return (
-    <div className="min-h-screen bg-secondary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-center gap-3">
-            <HelpCircle className="h-10 w-10 md:h-12 md:w-12" />
-            <h1 className="text-4xl font-bold md:text-5xl">よくある質問</h1>
-          </div>
-          <p className="mt-4 text-center text-lg opacity-90">
-            第97回 世田谷祭に関するよくある質問と回答
+    <PageSheetLayout hero={pageHeroes.faq}>
+      <div className="mx-auto max-w-4xl">
+        {/* FAQ件数表示 */}
+        <div className="mb-6">
+          <p className="text-sm text-gray-500">
+            <span className="font-semibold text-gray-900">{faqList.length}</span> 件の質問があります
           </p>
         </div>
-      </div>
 
-      <div className="container mx-auto px-4 py-12">
-        <div className="mx-auto max-w-4xl">
-          {/* FAQ件数表示 */}
-          <div className="mb-6">
-            <p className="text-sm text-gray-900/80">
-              <span className="font-semibold text-gray-900">{faqList.length}</span>{" "}
-              件の質問があります
+        {/* FAQ一覧 */}
+        {faqList.length > 0 ? (
+          <Accordion items={accordionItems} />
+        ) : (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center shadow-sm">
+            <p className="text-gray-500">現在、FAQは準備中です。</p>
+            <p className="mt-2 text-sm text-gray-400">
+              ご不明な点がございましたら、
+              <a href="/about/contact" className="text-primary hover:underline">
+                お問い合わせフォーム
+              </a>
+              よりお問い合わせください。
             </p>
           </div>
-
-          {/* FAQ一覧 */}
-          {faqList.length > 0 ? (
-            <Accordion items={accordionItems} />
-          ) : (
-            <div className="rounded-lg border border-gray-200/20 bg-white/10 p-8 text-center shadow-sm">
-              <p className="text-gray-900/60">現在、FAQは準備中です。</p>
-              <p className="mt-2 text-sm text-gray-900/50">
-                ご不明な点がございましたら、
-                <a href="/about/contact" className="text-primary-light hover:underline">
-                  お問い合わせフォーム
-                </a>
-                よりお問い合わせください。
-              </p>
-            </div>
-          )}
-        </div>
+        )}
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }

--- a/src/app/info/guide/page.tsx
+++ b/src/app/info/guide/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Info, AlertTriangle, Heart, Cloud, Package, Baby, Plus } from "lucide-react";
 import { guideConfig } from "@/data/guide";
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
 
 /**
  * メタデータ
@@ -22,231 +24,215 @@ export const metadata: Metadata = {
  */
 export default function GuidePage() {
   return (
-    <div className="min-h-screen bg-secondary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <h1 className="mb-4 text-center text-4xl font-bold md:text-5xl">ご来場の方へ</h1>
-          <p className="text-center text-lg opacity-90">
-            皆様に安全で快適にお過ごしいただくためのご案内
-          </p>
-        </div>
-      </div>
-
-      <div className="container mx-auto px-4 py-12">
-        <div className="mx-auto max-w-4xl space-y-12">
-          {/* 入場案内 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Info className="h-6 w-6 text-primary" />
-              <h2 className="text-2xl font-bold text-gray-900">入場案内</h2>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/60">入場料</p>
-                  <p className="text-xl font-bold text-primary-light">
-                    {guideConfig.admission.fee}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/60">開催時間</p>
-                  <p className="text-xl font-bold text-gray-900">{guideConfig.admission.time}</p>
-                </div>
-              </div>
-              <ul className="mt-4 space-y-2">
-                {guideConfig.admission.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-secondary"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
-          {/* 来場時の注意事項 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <AlertTriangle className="h-6 w-6 text-orange-500" />
-              <h2 className="text-2xl font-bold text-gray-900">来場時の注意事項</h2>
-            </div>
+    <PageSheetLayout hero={pageHeroes.guide}>
+      <div className="mx-auto max-w-4xl space-y-12">
+        {/* 入場案内 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Info className="h-6 w-6 text-primary" />
+            <h2 className="text-2xl font-bold text-gray-900">入場案内</h2>
+          </div>
+          <div className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
-              {guideConfig.precautions.map((item, index) => (
-                <div
-                  key={index}
-                  className="rounded-lg border border-gray-200/20 bg-white/10 p-4 transition-all hover:border-gray-200 hover:shadow-md"
-                >
-                  <div className="mb-2 flex items-center gap-2">
-                    <span className="text-2xl">{item.icon}</span>
-                    <h3 className="font-bold text-gray-900">{item.category}</h3>
-                  </div>
-                  <p className="text-sm text-gray-900/90">{item.content}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* バリアフリー情報 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Heart className="h-6 w-6 text-pink-500" />
-              <h2 className="text-2xl font-bold text-gray-900">バリアフリー情報</h2>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="rounded-lg bg-white/10 p-4 text-center">
-                  <p className="mb-1 text-sm font-semibold text-gray-900/80">車椅子対応</p>
-                  <p className="text-lg font-bold text-pink-600">
-                    {guideConfig.accessibility.wheelchairAccessible ? "対応" : "非対応"}
-                  </p>
-                </div>
-                <div className="rounded-lg bg-white/10 p-4 text-center">
-                  <p className="mb-1 text-sm font-semibold text-gray-900/80">多目的トイレ</p>
-                  <p className="text-lg font-bold text-pink-600">
-                    {guideConfig.accessibility.multipurposeRestrooms ? "あり" : "なし"}
-                  </p>
-                </div>
-                <div className="rounded-lg bg-white/10 p-4 text-center">
-                  <p className="mb-1 text-sm font-semibold text-gray-900/80">授乳室</p>
-                  <p className="text-lg font-bold text-pink-600">
-                    {guideConfig.accessibility.nursingRoom ? "あり" : "なし"}
-                  </p>
-                </div>
+              <div>
+                <p className="text-sm font-semibold text-gray-500">入場料</p>
+                <p className="text-xl font-bold text-primary">{guideConfig.admission.fee}</p>
               </div>
               <div>
-                <p className="mb-2 font-semibold text-gray-900">エレベーター設置棟:</p>
-                <p className="text-gray-900/90">{guideConfig.accessibility.elevators.join("、")}</p>
+                <p className="text-sm font-semibold text-gray-500">開催時間</p>
+                <p className="text-xl font-bold text-gray-900">{guideConfig.admission.time}</p>
               </div>
-              <ul className="space-y-2">
-                {guideConfig.accessibility.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-pink-500"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
             </div>
-          </section>
+            <ul className="mt-4 space-y-2">
+              {guideConfig.admission.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-primary"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
 
-          {/* 天候による影響 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Cloud className="h-6 w-6 text-blue-500" />
-              <h2 className="text-2xl font-bold text-gray-900">天候による影響</h2>
-            </div>
-            <div className="space-y-3">
-              <p className="text-lg font-semibold text-blue-600">
-                {guideConfig.weatherInfo.rainPolicy}
-              </p>
-              <ul className="space-y-2">
-                {guideConfig.weatherInfo.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
-          {/* 落とし物・忘れ物 */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Package className="h-6 w-6 text-green-500" />
-              <h2 className="text-2xl font-bold text-gray-900">落とし物・忘れ物</h2>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/60">受付場所</p>
-                  <p className="text-lg font-bold text-gray-900">
-                    {guideConfig.lostAndFound.location}
-                  </p>
+        {/* 来場時の注意事項 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <AlertTriangle className="h-6 w-6 text-orange-500" />
+            <h2 className="text-2xl font-bold text-gray-900">来場時の注意事項</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {guideConfig.precautions.map((item, index) => (
+              <div
+                key={index}
+                className="rounded-lg border border-gray-200 bg-gray-100 p-4 transition-all hover:border-gray-300 hover:shadow-md"
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="text-2xl">{item.icon}</span>
+                  <h3 className="font-bold text-gray-900">{item.category}</h3>
                 </div>
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/60">受付時間</p>
-                  <p className="text-lg font-bold text-gray-900">
-                    {guideConfig.lostAndFound.hours}
-                  </p>
-                </div>
+                <p className="text-sm text-gray-700">{item.content}</p>
               </div>
-              <ul className="space-y-2">
-                {guideConfig.lostAndFound.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-green-500"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </section>
+            ))}
+          </div>
+        </section>
 
-          {/* お子様連れの方へ */}
-          <section className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Baby className="h-6 w-6 text-purple-500" />
-              <h2 className="text-2xl font-bold text-gray-900">お子様連れの方へ</h2>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="rounded-lg bg-white/10 p-4">
-                  <p className="mb-1 text-sm font-semibold text-gray-900/80">授乳室</p>
-                  <p className="font-bold text-purple-600">
-                    {guideConfig.forFamilies.nursingRoom ? "あり" : "なし"}
-                  </p>
-                </div>
-                <div className="rounded-lg bg-white/10 p-4">
-                  <p className="mb-1 text-sm font-semibold text-gray-900/80">おむつ交換台</p>
-                  <p className="font-bold text-purple-600">
-                    {guideConfig.forFamilies.diaperChangingStation ? "あり" : "なし"}
-                  </p>
-                </div>
+        {/* バリアフリー情報 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Heart className="h-6 w-6 text-pink-500" />
+            <h2 className="text-2xl font-bold text-gray-900">バリアフリー情報</h2>
+          </div>
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-3">
+              <div className="rounded-lg bg-gray-100 p-4 text-center">
+                <p className="mb-1 text-sm font-semibold text-gray-600">車椅子対応</p>
+                <p className="text-lg font-bold text-pink-600">
+                  {guideConfig.accessibility.wheelchairAccessible ? "対応" : "非対応"}
+                </p>
               </div>
-              <ul className="space-y-2">
-                {guideConfig.forFamilies.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-purple-500"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
+              <div className="rounded-lg bg-gray-100 p-4 text-center">
+                <p className="mb-1 text-sm font-semibold text-gray-600">多目的トイレ</p>
+                <p className="text-lg font-bold text-pink-600">
+                  {guideConfig.accessibility.multipurposeRestrooms ? "あり" : "なし"}
+                </p>
+              </div>
+              <div className="rounded-lg bg-gray-100 p-4 text-center">
+                <p className="mb-1 text-sm font-semibold text-gray-600">授乳室</p>
+                <p className="text-lg font-bold text-pink-600">
+                  {guideConfig.accessibility.nursingRoom ? "あり" : "なし"}
+                </p>
+              </div>
             </div>
-          </section>
+            <div>
+              <p className="mb-2 font-semibold text-gray-900">エレベーター設置棟:</p>
+              <p className="text-gray-700">{guideConfig.accessibility.elevators.join("、")}</p>
+            </div>
+            <ul className="space-y-2">
+              {guideConfig.accessibility.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-pink-500"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
 
-          {/* 緊急時の対応 */}
-          <section className="rounded-lg border border-red-400/30 bg-red-900/20 p-6 shadow-sm md:p-8">
-            <div className="mb-6 flex items-center gap-3">
-              <Plus className="h-6 w-6 text-red-500" />
-              <h2 className="text-2xl font-bold text-gray-900">緊急時の対応</h2>
-            </div>
-            <div className="space-y-4">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/80">救護室</p>
-                  <p className="text-lg font-bold text-red-600">
-                    {guideConfig.emergency.medicalRoom}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-gray-900/80">緊急連絡先</p>
-                  <p className="text-lg font-bold text-red-600">
-                    {guideConfig.emergency.emergencyContact}
-                  </p>
-                </div>
+        {/* 天候による影響 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Cloud className="h-6 w-6 text-blue-500" />
+            <h2 className="text-2xl font-bold text-gray-900">天候による影響</h2>
+          </div>
+          <div className="space-y-3">
+            <p className="text-lg font-semibold text-blue-600">
+              {guideConfig.weatherInfo.rainPolicy}
+            </p>
+            <ul className="space-y-2">
+              {guideConfig.weatherInfo.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* 落とし物・忘れ物 */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Package className="h-6 w-6 text-green-500" />
+            <h2 className="text-2xl font-bold text-gray-900">落とし物・忘れ物</h2>
+          </div>
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-sm font-semibold text-gray-500">受付場所</p>
+                <p className="text-lg font-bold text-gray-900">
+                  {guideConfig.lostAndFound.location}
+                </p>
               </div>
-              <ul className="space-y-2">
-                {guideConfig.emergency.notes.map((note, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-900/90">
-                    <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
-                    <span>{note}</span>
-                  </li>
-                ))}
-              </ul>
+              <div>
+                <p className="text-sm font-semibold text-gray-500">受付時間</p>
+                <p className="text-lg font-bold text-gray-900">{guideConfig.lostAndFound.hours}</p>
+              </div>
             </div>
-          </section>
-        </div>
+            <ul className="space-y-2">
+              {guideConfig.lostAndFound.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-green-500"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* お子様連れの方へ */}
+        <section className="rounded-lg border border-gray-200 bg-gray-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Baby className="h-6 w-6 text-purple-500" />
+            <h2 className="text-2xl font-bold text-gray-900">お子様連れの方へ</h2>
+          </div>
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-lg bg-gray-100 p-4">
+                <p className="mb-1 text-sm font-semibold text-gray-600">授乳室</p>
+                <p className="font-bold text-purple-600">
+                  {guideConfig.forFamilies.nursingRoom ? "あり" : "なし"}
+                </p>
+              </div>
+              <div className="rounded-lg bg-gray-100 p-4">
+                <p className="mb-1 text-sm font-semibold text-gray-600">おむつ交換台</p>
+                <p className="font-bold text-purple-600">
+                  {guideConfig.forFamilies.diaperChangingStation ? "あり" : "なし"}
+                </p>
+              </div>
+            </div>
+            <ul className="space-y-2">
+              {guideConfig.forFamilies.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-purple-500"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* 緊急時の対応 */}
+        <section className="rounded-lg border border-red-200 bg-red-50 p-6 shadow-sm md:p-8">
+          <div className="mb-6 flex items-center gap-3">
+            <Plus className="h-6 w-6 text-red-500" />
+            <h2 className="text-2xl font-bold text-gray-900">緊急時の対応</h2>
+          </div>
+          <div className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <p className="text-sm font-semibold text-gray-600">救護室</p>
+                <p className="text-lg font-bold text-red-600">
+                  {guideConfig.emergency.medicalRoom}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-gray-600">緊急連絡先</p>
+                <p className="text-lg font-bold text-red-600">
+                  {guideConfig.emergency.emergencyContact}
+                </p>
+              </div>
+            </div>
+            <ul className="space-y-2">
+              {guideConfig.emergency.notes.map((note, index) => (
+                <li key={index} className="flex items-start gap-2 text-gray-700">
+                  <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500"></span>
+                  <span>{note}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -109,6 +109,9 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
     if (typeof window === "undefined") return;
     if (ctxRef.current) return;
 
+    // Openerが稼働中かどうかをDOM存在で判定
+    const hasOpener = !!document.querySelector(".opener-container");
+
     const runEntrance = () => {
       if (!sectionRef.current || ctxRef.current) return;
 
@@ -131,7 +134,8 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
           gsap.set(navItems, { opacity: 0, x: -15 });
         }
 
-        const tl = gsap.timeline({ delay: 0.3 });
+        // Opener後は0.3sの"呼吸"、不在時はdelay無し
+        const tl = gsap.timeline({ delay: hasOpener ? 0.3 : 0 });
 
         // メイン要素: stagger 0.12s で順次出現
         tl.to(
@@ -170,15 +174,23 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
       ctxRef.current = ctx;
     };
 
-    // opener-doneイベント監視
-    window.addEventListener("opener-done", runEntrance);
+    if (!hasOpener) {
+      // Opener完了済み/不在 → 即座にアニメーション実行
+      runEntrance();
+    } else {
+      // Opener稼働中 → イベント待機 + フェイルセーフ
+      window.addEventListener("opener-done", runEntrance);
+      const failsafe = setTimeout(runEntrance, 5000);
 
-    // フェイルセーフ: 5秒後に強制開始（ページ内遷移等でopener-done未発火時）
-    const failsafe = setTimeout(runEntrance, 5000);
+      return () => {
+        window.removeEventListener("opener-done", runEntrance);
+        clearTimeout(failsafe);
+        ctxRef.current?.revert();
+        ctxRef.current = null;
+      };
+    }
 
     return () => {
-      window.removeEventListener("opener-done", runEntrance);
-      clearTimeout(failsafe);
       ctxRef.current?.revert();
       ctxRef.current = null;
     };

--- a/src/components/ui/Accordion.tsx
+++ b/src/components/ui/Accordion.tsx
@@ -25,7 +25,7 @@ function AccordionItem({ item, index }: AccordionItemProps) {
   };
 
   return (
-    <div className="rounded-lg border border-gray-200/20 bg-white/10">
+    <div className="rounded-lg border border-gray-200 bg-gray-50">
       {/* アコーディオンのヘッダー部分 */}
       <button
         type="button"
@@ -33,7 +33,7 @@ function AccordionItem({ item, index }: AccordionItemProps) {
         onKeyDown={handleKeyDown}
         aria-expanded={isOpen}
         aria-controls={`accordion-content-${index}`}
-        className="flex w-full items-center justify-between p-4 text-left hover:bg-white/10"
+        className="flex w-full items-center justify-between p-4 text-left hover:bg-gray-100"
       >
         <span className="text-base font-semibold text-gray-900 md:text-lg">{item.title}</span>
         <ChevronDown
@@ -46,7 +46,7 @@ function AccordionItem({ item, index }: AccordionItemProps) {
         id={`accordion-content-${index}`}
         className={cn("overflow-hidden", isOpen ? "max-h-screen opacity-100" : "max-h-0 opacity-0")}
       >
-        <div className="border-t border-gray-200/20 p-4">
+        <div className="border-t border-gray-200 p-4">
           <p className="whitespace-pre-wrap text-sm text-gray-900/90 md:text-base">
             {item.content}
           </p>

--- a/src/data/page-heroes.ts
+++ b/src/data/page-heroes.ts
@@ -61,4 +61,32 @@ export const pageHeroes: Record<string, PageHeroData> = {
     imageSrc: "/images/placeholder/pastel-castle.webp",
     imageAlt: "実行委員会の活動風景",
   },
+  contact: {
+    title: "お問い合わせ",
+    subtitle: "Contact",
+    description: "第97回 世田谷祭に関するご質問・ご相談",
+    imageSrc: "/images/placeholder/pastel-castle.webp",
+    imageAlt: "お問い合わせ",
+  },
+  privacy: {
+    title: "プライバシーポリシー",
+    subtitle: "Privacy Policy",
+    description: "個人情報保護方針",
+    imageSrc: "/images/placeholder/pastel-castle.webp",
+    imageAlt: "プライバシーポリシー",
+  },
+  guide: {
+    title: "ご来場の方へ",
+    subtitle: "Visitor Guide",
+    description: "皆様に安全で快適にお過ごしいただくためのご案内",
+    imageSrc: "/images/placeholder/pastel-castle.webp",
+    imageAlt: "来場ガイド",
+  },
+  faq: {
+    title: "よくある質問",
+    subtitle: "FAQ",
+    description: "第97回 世田谷祭に関するよくある質問と回答",
+    imageSrc: "/images/placeholder/pastel-castle.webp",
+    imageAlt: "よくある質問",
+  },
 };


### PR DESCRIPTION
## Summary
- about/info系の4ページ（contact, privacy, guide, faq）を `PageSheetLayout`（ヒーロー + 白シート）パターンに統一
- `page-heroes.ts` に4ページ分のヒーローデータを追加
- `Accordion.tsx` / `ContactForm.tsx` の共有コンポーネントを白背景用スタイルに更新
- `bg-white/10` 半透明カード → `bg-gray-50` 不透明カードへ全面置換し、可読性を改善

## 変更対象
| ファイル | 変更内容 |
|---|---|
| `src/data/page-heroes.ts` | contact/privacy/guide/faq ヒーローデータ追加 |
| `src/components/ui/Accordion.tsx` | 白背景用スタイルに更新 |
| `src/app/about/contact/ContactForm.tsx` | フォーム入力欄・送信ボタンを白背景用に |
| `src/app/about/contact/page.tsx` | PageSheetLayoutでラップ |
| `src/app/about/privacy/page.tsx` | PageSheetLayoutでラップ |
| `src/app/info/guide/page.tsx` | PageSheetLayoutでラップ |
| `src/app/info/faq/page.tsx` | PageSheetLayoutでラップ |
| `src/components/home/HeroSection.tsx` | 既存修正を含む |

## Test plan
- [ ] `pnpm build` でビルドエラーなし（確認済み）
- [ ] `pnpm lint` でESLintエラーなし（確認済み）
- [ ] `/about/contact` にヒーロー + 白シートが表示される
- [ ] `/about/privacy` にヒーロー + 白シートが表示される
- [ ] `/info/guide` にヒーロー + 白シートが表示される
- [ ] `/info/faq` にヒーロー + 白シートが表示される
- [ ] フォーム入力欄・ボタンの視認性が改善されている
- [ ] `/about` ページとのデザイン統一感を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)