### PR TITLE
FIX: microCMSフィルタ構文修正・UI調整

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,3 @@ MICROCMS_API_KEY=***
 # サイト情報
 NEXT_PUBLIC_URL=https://yamashitamana.to
 NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
-
-# お問い合わせフォーム（SMTP設定）
-# Gmail: smtp.gmail.com:587, SendGrid: smtp.sendgrid.net:587
-SMTP_HOST=smtp.gmail.com
-SMTP_PORT=587
-SMTP_USER=your-email@gmail.com
-SMTP_PASS=your-app-password
-CONTACT_TO_EMAIL=contact@setagayafes.com
-CONTACT_FROM_EMAIL=noreply@setagayafes.com

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -76,22 +76,22 @@ export function AboutSection() {
           {/* 右: テキストコンテンツ */}
           <div>
             {/* ラベル */}
-            <p className="mb-4 text-xs uppercase tracking-widest text-gray-500">
+            <p className="mb-4 text-xs uppercase tracking-widest text-white/60">
               {topSection.label}
             </p>
 
             {/* 見出し */}
-            <h2 className="mb-4 text-4xl font-bold text-primary-400 md:text-5xl lg:text-6xl">
+            <h2 className="mb-4 text-4xl font-bold text-white md:text-5xl lg:text-6xl">
               {topSection.heading}
             </h2>
 
             {/* タグライン */}
-            <p className="mb-8 text-lg font-medium text-gray-700">{topSection.tagline}</p>
+            <p className="mb-8 text-lg font-medium text-white/80">{topSection.tagline}</p>
 
             {/* 本文 */}
             <div className="mb-10 space-y-4">
               {topSection.paragraphs.map((paragraph, i) => (
-                <p key={i} className="leading-relaxed text-gray-600">
+                <p key={i} className="leading-relaxed text-white/70">
                   {paragraph}
                 </p>
               ))}
@@ -100,7 +100,7 @@ export function AboutSection() {
             {/* CTA */}
             <Link
               href={topSection.cta.href}
-              className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-400 underline underline-offset-4 transition-opacity hover:opacity-70"
+              className="group inline-flex items-center gap-2 text-sm font-semibold text-white underline underline-offset-4 transition-opacity hover:opacity-70"
             >
               {topSection.cta.label}
               <svg

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -11,9 +11,14 @@ const { topSection } = aboutConfig;
  */
 export function AboutSection() {
   return (
-    <section className="relative -mt-48 pt-72 pb-24 lg:pt-80 lg:pb-32 overflow-hidden bg-[var(--color-secondary)]">
-      {/* z-0: 背景グラデーションblob（ピンク系グロウ） */}
-      <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
+    <section
+      className="relative -mt-48 pt-72 pb-24 lg:pt-80 lg:pb-32 overflow-hidden"
+      style={{
+        background: "linear-gradient(to bottom, transparent 0%, var(--color-secondary) 380px)",
+      }}
+    >
+      {/* 背景グラデーションblob（ピンク系グロウ） */}
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
         <div
           className="animate-blob absolute top-[10%] right-[0%] h-[50%] w-[45%] rounded-full"
           style={{
@@ -40,17 +45,7 @@ export function AboutSection() {
         />
       </div>
 
-      {/* z-10: 白グラデーションオーバーレイ（上部白→下部透明） */}
-      <div
-        className="pointer-events-none absolute inset-x-0 top-48 bottom-0 z-10"
-        aria-hidden="true"
-        style={{
-          background:
-            "linear-gradient(to bottom, white 0%, white 15%, rgba(255,255,255,0.7) 30%, rgba(255,255,255,0.3) 50%, rgba(255,255,255,0.08) 70%, transparent 85%)",
-        }}
-      />
-
-      <div className="relative z-20 mx-auto max-w-6xl px-8 sm:px-12 lg:px-20">
+      <div className="mx-auto max-w-6xl px-8 sm:px-12 lg:px-20">
         <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2 lg:gap-16">
           {/* 左: 円形画像 + 歯車装飾 */}
           <div className="flex justify-center">
@@ -86,7 +81,7 @@ export function AboutSection() {
             </p>
 
             {/* 見出し */}
-            <h2 className="mb-4 text-4xl font-bold text-primary md:text-5xl lg:text-6xl">
+            <h2 className="mb-4 text-4xl font-bold text-primary-400 md:text-5xl lg:text-6xl">
               {topSection.heading}
             </h2>
 
@@ -105,7 +100,7 @@ export function AboutSection() {
             {/* CTA */}
             <Link
               href={topSection.cta.href}
-              className="group inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-md transition-all hover:bg-primary/85 hover:shadow-lg"
+              className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-400 underline underline-offset-4 transition-opacity hover:opacity-70"
             >
               {topSection.cta.label}
               <svg

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -11,14 +11,9 @@ const { topSection } = aboutConfig;
  */
 export function AboutSection() {
   return (
-    <section
-      className="relative -mt-48 pt-72 pb-24 lg:pt-80 lg:pb-32 overflow-hidden"
-      style={{
-        background: "linear-gradient(to bottom, transparent 0%, var(--color-secondary) 380px)",
-      }}
-    >
-      {/* 背景グラデーションblob（ピンク系グロウ） */}
-      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+    <section className="relative -mt-48 pt-72 pb-24 lg:pt-80 lg:pb-32 overflow-hidden bg-[var(--color-secondary)]">
+      {/* z-0: 背景グラデーションblob（ピンク系グロウ） */}
+      <div className="pointer-events-none absolute inset-0 z-0" aria-hidden="true">
         <div
           className="animate-blob absolute top-[10%] right-[0%] h-[50%] w-[45%] rounded-full"
           style={{
@@ -45,7 +40,17 @@ export function AboutSection() {
         />
       </div>
 
-      <div className="mx-auto max-w-6xl px-8 sm:px-12 lg:px-20">
+      {/* z-10: 白グラデーションオーバーレイ（上部白→下部透明） */}
+      <div
+        className="pointer-events-none absolute inset-x-0 top-48 bottom-0 z-10"
+        aria-hidden="true"
+        style={{
+          background:
+            "linear-gradient(to bottom, white 0%, white 15%, rgba(255,255,255,0.7) 30%, rgba(255,255,255,0.3) 50%, rgba(255,255,255,0.08) 70%, transparent 85%)",
+        }}
+      />
+
+      <div className="relative z-20 mx-auto max-w-6xl px-8 sm:px-12 lg:px-20">
         <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-2 lg:gap-16">
           {/* 左: 円形画像 + 歯車装飾 */}
           <div className="flex justify-center">
@@ -81,7 +86,7 @@ export function AboutSection() {
             </p>
 
             {/* 見出し */}
-            <h2 className="mb-4 text-4xl font-bold text-primary-400 md:text-5xl lg:text-6xl">
+            <h2 className="mb-4 text-4xl font-bold text-primary md:text-5xl lg:text-6xl">
               {topSection.heading}
             </h2>
 
@@ -100,7 +105,7 @@ export function AboutSection() {
             {/* CTA */}
             <Link
               href={topSection.cta.href}
-              className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-400 underline underline-offset-4 transition-opacity hover:opacity-70"
+              className="group inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-md transition-all hover:bg-primary/85 hover:shadow-lg"
             >
               {topSection.cta.label}
               <svg

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -28,12 +28,12 @@ function DateBlock({ dateStr }: { dateStr: string }) {
   const { month, day, dayOfWeek } = getDateParts(dateStr);
 
   return (
-    <div className="flex items-center text-white">
+    <div className="flex items-center text-primary-400">
       <span className="text-5xl md:text-6xl lg:text-7xl font-serif italic leading-none -translate-y-1.5 md:-translate-y-2">
         {month}
       </span>
       <div className="relative mx-0.5 md:mx-1 flex items-center justify-center">
-        <div className="w-px h-14 md:h-20 lg:h-24 bg-white/60 rotate-[-25deg]" />
+        <div className="w-px h-14 md:h-20 lg:h-24 bg-primary-400/60 rotate-[-25deg]" />
       </div>
       <span className="text-5xl md:text-6xl lg:text-7xl font-serif italic leading-none translate-y-1.5 md:translate-y-2">
         {day}
@@ -263,20 +263,20 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
         className="absolute left-0 bottom-0 z-30 px-6 lg:px-8 pb-12 lg:pb-16 will-change-transform opacity-0"
         aria-label={`開催日: ${siteConfig.dates.day1} - ${siteConfig.dates.day2}`}
       >
-        <p className="text-sm md:text-base font-serif italic tracking-[0.3em] text-white mb-2 md:mb-3">
+        <p className="text-sm md:text-base font-serif italic tracking-[0.3em] text-primary-400 mb-2 md:mb-3">
           {getDateParts(siteConfig.dates.day1).year}
         </p>
         <div className="flex items-center gap-4 md:gap-6 lg:gap-8">
           <DateBlock dateStr={siteConfig.dates.day1} />
           <DateBlock dateStr={siteConfig.dates.day2} />
         </div>
-        <p className="text-xs md:text-sm tracking-[0.2em] text-white/80 mt-2 md:mt-3">
+        <p className="text-xs md:text-sm tracking-[0.2em] text-primary-400/70 mt-2 md:mt-3">
           {siteConfig.openTime} - {siteConfig.closeTime}
         </p>
         {/* モバイル用CTA（md以上では非表示） */}
         <Link
           href="/events"
-          className="inline-block bg-white text-primary-400 text-sm font-medium px-6 py-3 rounded-full hover:bg-white/90 transition-colors mt-4 md:hidden"
+          className="inline-block bg-primary-400 text-white text-sm font-medium px-6 py-3 rounded-full hover:bg-primary-300 transition-colors mt-4 md:hidden"
         >
           企画を探す
         </Link>
@@ -292,24 +292,34 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
             <span
               className={cn(
                 "text-xs font-medium px-2 py-0.5 rounded",
-                latestNews.type === "urgent" ? "bg-red-500 text-white" : "bg-white/15 text-white"
+                latestNews.type === "urgent" ? "bg-red-500 text-white" : "bg-gray-200 text-gray-700"
               )}
             >
               {getNewsTypeLabel(latestNews.type)}
             </span>
-            <span className="text-xs text-white/60">{formatNewsDate(latestNews.publishedAt)}</span>
+            <span className="text-xs text-gray-500">{formatNewsDate(latestNews.publishedAt)}</span>
           </div>
-          <p className="text-sm md:text-base text-white font-medium line-clamp-2 mb-3">
+          <p className="text-sm md:text-base text-gray-700 font-medium line-clamp-2 mb-3">
             {latestNews.title}
           </p>
           <Link
             href={`/info/${latestNews.id}`}
-            className="text-sm text-white hover:text-white/80 transition-colors font-medium"
+            className="text-sm text-gray-700 hover:text-gray-500 transition-colors font-medium"
           >
             詳しく見る →
           </Link>
         </div>
       )}
+
+      {/* 下部グラデーションオーバーレイ（transparent → white） */}
+      <div
+        className="pointer-events-none absolute bottom-0 left-0 right-0 h-48 md:h-56"
+        aria-hidden="true"
+        style={{
+          background: "linear-gradient(to bottom, transparent, white)",
+          zIndex: 15,
+        }}
+      />
     </section>
   );
 }

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -28,12 +28,12 @@ function DateBlock({ dateStr }: { dateStr: string }) {
   const { month, day, dayOfWeek } = getDateParts(dateStr);
 
   return (
-    <div className="flex items-center text-primary-400">
+    <div className="flex items-center text-white">
       <span className="text-5xl md:text-6xl lg:text-7xl font-serif italic leading-none -translate-y-1.5 md:-translate-y-2">
         {month}
       </span>
       <div className="relative mx-0.5 md:mx-1 flex items-center justify-center">
-        <div className="w-px h-14 md:h-20 lg:h-24 bg-primary-400/60 rotate-[-25deg]" />
+        <div className="w-px h-14 md:h-20 lg:h-24 bg-white/60 rotate-[-25deg]" />
       </div>
       <span className="text-5xl md:text-6xl lg:text-7xl font-serif italic leading-none translate-y-1.5 md:translate-y-2">
         {day}
@@ -263,20 +263,20 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
         className="absolute left-0 bottom-0 z-30 px-6 lg:px-8 pb-12 lg:pb-16 will-change-transform opacity-0"
         aria-label={`開催日: ${siteConfig.dates.day1} - ${siteConfig.dates.day2}`}
       >
-        <p className="text-sm md:text-base font-serif italic tracking-[0.3em] text-primary-400 mb-2 md:mb-3">
+        <p className="text-sm md:text-base font-serif italic tracking-[0.3em] text-white mb-2 md:mb-3">
           {getDateParts(siteConfig.dates.day1).year}
         </p>
         <div className="flex items-center gap-4 md:gap-6 lg:gap-8">
           <DateBlock dateStr={siteConfig.dates.day1} />
           <DateBlock dateStr={siteConfig.dates.day2} />
         </div>
-        <p className="text-xs md:text-sm tracking-[0.2em] text-primary-400/70 mt-2 md:mt-3">
+        <p className="text-xs md:text-sm tracking-[0.2em] text-white/80 mt-2 md:mt-3">
           {siteConfig.openTime} - {siteConfig.closeTime}
         </p>
         {/* モバイル用CTA（md以上では非表示） */}
         <Link
           href="/events"
-          className="inline-block bg-primary-400 text-white text-sm font-medium px-6 py-3 rounded-full hover:bg-primary-300 transition-colors mt-4 md:hidden"
+          className="inline-block bg-white text-primary-400 text-sm font-medium px-6 py-3 rounded-full hover:bg-white/90 transition-colors mt-4 md:hidden"
         >
           企画を探す
         </Link>
@@ -292,34 +292,24 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
             <span
               className={cn(
                 "text-xs font-medium px-2 py-0.5 rounded",
-                latestNews.type === "urgent" ? "bg-red-500 text-white" : "bg-gray-200 text-gray-700"
+                latestNews.type === "urgent" ? "bg-red-500 text-white" : "bg-white/15 text-white"
               )}
             >
               {getNewsTypeLabel(latestNews.type)}
             </span>
-            <span className="text-xs text-gray-500">{formatNewsDate(latestNews.publishedAt)}</span>
+            <span className="text-xs text-white/60">{formatNewsDate(latestNews.publishedAt)}</span>
           </div>
-          <p className="text-sm md:text-base text-gray-700 font-medium line-clamp-2 mb-3">
+          <p className="text-sm md:text-base text-white font-medium line-clamp-2 mb-3">
             {latestNews.title}
           </p>
           <Link
             href={`/info/${latestNews.id}`}
-            className="text-sm text-gray-700 hover:text-gray-500 transition-colors font-medium"
+            className="text-sm text-white hover:text-white/80 transition-colors font-medium"
           >
             詳しく見る →
           </Link>
         </div>
       )}
-
-      {/* 下部グラデーションオーバーレイ（transparent → white） */}
-      <div
-        className="pointer-events-none absolute bottom-0 left-0 right-0 h-48 md:h-56"
-        aria-hidden="true"
-        style={{
-          background: "linear-gradient(to bottom, transparent, white)",
-          zIndex: 15,
-        }}
-      />
     </section>
   );
 }

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -185,6 +185,15 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
         />
       </div>
 
+      {/* [z-15] 白グラデーションマスク（上:透明 → 下:白） */}
+      <div
+        className="pointer-events-none absolute inset-0 z-15"
+        aria-hidden="true"
+        style={{
+          background: "linear-gradient(to top, transparent 0%, white 100%)",
+        }}
+      />
+
       {/* [z-20] ロゴ画像（中央配置） */}
       <div
         ref={gearRef}

--- a/src/components/home/SponsorLogoLoop.tsx
+++ b/src/components/home/SponsorLogoLoop.tsx
@@ -78,7 +78,7 @@ export function SponsorLogoLoop({ sponsors }: SponsorLogoLoopProps) {
         logoHeight={40}
         gap={48}
         fadeOut
-        fadeOutColor="oklch(68% 0.175 314deg)"
+        fadeOutColor="oklch(83% 0.07 345deg)"
         ariaLabel="協賛企業ロゴ"
         renderItem={renderItem}
       />

--- a/src/components/home/SponsorLogoLoop.tsx
+++ b/src/components/home/SponsorLogoLoop.tsx
@@ -78,7 +78,7 @@ export function SponsorLogoLoop({ sponsors }: SponsorLogoLoopProps) {
         logoHeight={40}
         gap={48}
         fadeOut
-        fadeOutColor="oklch(83% 0.07 345deg)"
+        fadeOutColor="oklch(68% 0.175 314deg)"
         ariaLabel="協賛企業ロゴ"
         renderItem={renderItem}
       />

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -137,10 +137,10 @@ export async function getEventsList(
     // microCMS filters パラメータの構築
     const filterQueries: string[] = [];
     if (filters?.date) {
-      filterQueries.push(`date[equals]${filters.date}`);
+      filterQueries.push(`date[contains]${filters.date}`);
     }
     if (filters?.type) {
-      filterQueries.push(`type[equals]${filters.type}`);
+      filterQueries.push(`type[contains]${filters.type}`);
     }
     if (filters?.building) {
       filterQueries.push(`building[equals]${filters.building}`);

--- a/src/lib/informations.ts
+++ b/src/lib/informations.ts
@@ -58,7 +58,7 @@ export async function getSponsorsList(): Promise<Information[]> {
       endpoint: "informations",
       queries: {
         limit: 100,
-        filters: "category[contains]sponsor : 協賛企業",
+        filters: "category[contains]sponsor",
         orders: "-priority",
       },
     });


### PR DESCRIPTION
## Summary
- microCMS Selectフィールドのフィルタ演算子を`[equals]`から`[contains]`に修正（events.ts, informations.ts）
- informationsのフィルタ値から不正な表示名（`: 協賛企業`）を除去
- AboutSectionのテキスト色を白系に統一（暗背景対応）
- HeroSectionに白グラデーションマスクを追加
- .env.exampleからSMTP設定プレースホルダーを削除

## Test plan
- [x] `pnpm build` でビルド成功を確認（全53ページ生成、404エラーなし）
- [x] curlで全3API（news, events, informations）が200を返すことを確認
- [ ] `pnpm dev` でブラウザ上の各ページ表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)