### PR TITLE
STYLE: Hero背景グラデを薄紫トーンに統一・上部まで拡張

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,9 +136,10 @@ body {
   .hero-about-bg {
     background: linear-gradient(
       to bottom,
-      #ffffff 20%,
-      var(--color-primary-200) 35%,
-      var(--color-secondary) 50%
+      #ffffff 0%,
+      var(--color-primary-50) 15%,
+      var(--color-primary-100) 50%,
+      var(--color-secondary) 80%
     );
   }
 
@@ -146,9 +147,10 @@ body {
     .hero-about-bg {
       background: linear-gradient(
         to bottom,
-        #ffffff 25%,
-        var(--color-primary-200) 40%,
-        var(--color-secondary) 55%
+        #ffffff 0%,
+        var(--color-primary-50) 20%,
+        var(--color-primary-100) 55%,
+        var(--color-secondary) 85%
       );
     }
   }


### PR DESCRIPTION
## Summary
- `.hero-about-bg` のモバイル/デスクトップ両方で `primary-50` / `primary-100` ベースの薄紫グラデに変更
- `#ffffff` の停止位置を 0% に下げ、画面上部から薄紫が立ち上がる構成に
- デスクトップ側もモバイルと同系統トーンに統一（stop位置のみビューポート高に合わせ後ろ倒し）

## Test plan
- [ ] モバイル（〜375px）でHero上部から薄紫が立ち上がることを確認
- [ ] タブレット/デスクトップ（768px以上）でも同系統の薄紫トーンになることを確認
- [ ] AboutSectionへのつなぎが不自然でないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)