### PR TITLE
FEATURE: 公式SNSリンクを更新（X/Instagram新URL・Facebook→YouTube移行）

### DIFF
--- a/src/components/layout/StaggeredMobileMenu.tsx
+++ b/src/components/layout/StaggeredMobileMenu.tsx
@@ -35,7 +35,7 @@ const menuItems: MenuItem[] = getFilteredHeaderNav().map((item) => ({
 const socialItems: SocialItem[] = [
   { label: "X (Twitter)", link: siteConfig.sns.twitter },
   { label: "Instagram", link: siteConfig.sns.instagram },
-  { label: "Facebook", link: siteConfig.sns.facebook },
+  { label: "YouTube", link: siteConfig.sns.youtube },
 ];
 
 const PRE_COLORS = ["#E1C0EE", "#CD79EE"];

--- a/src/components/ui/SocialIcons.tsx
+++ b/src/components/ui/SocialIcons.tsx
@@ -1,4 +1,4 @@
-import { Facebook, Instagram } from "lucide-react";
+import { Instagram, Youtube } from "lucide-react";
 import { siteConfig } from "@/data/site";
 
 export interface SocialIconsProps {
@@ -52,9 +52,9 @@ export function SocialIcons({
       icon: <Instagram className={iconSizes[size]} />,
     },
     {
-      name: "Facebook",
-      url: siteConfig.sns.facebook,
-      icon: <Facebook className={iconSizes[size]} />,
+      name: "YouTube",
+      url: siteConfig.sns.youtube,
+      icon: <Youtube className={iconSizes[size]} />,
     },
   ];
 

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -111,13 +111,18 @@ export const aboutConfig = {
   social: [
     {
       name: "X (Twitter)",
-      url: "https://twitter.com/setagayafes_tcu",
+      url: "https://x.com/setagayafes_tcu?s=11",
       icon: "twitter",
     },
     {
       name: "Instagram",
-      url: "https://instagram.com/setagayafes_sfa",
+      url: "https://www.instagram.com/setagayafes_sfa?igsh=bWpzYWpqOGozZ3Nr&utm_source=qr",
       icon: "instagram",
+    },
+    {
+      name: "YouTube",
+      url: "https://youtube.com/@setagayafes?si=WvB8ya5RrqvHg0Vj",
+      icon: "youtube",
     },
   ],
 

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -33,9 +33,9 @@ export const siteConfig = {
 
   // SNS
   sns: {
-    twitter: "https://twitter.com/tcu_setagayafes",
-    instagram: "https://instagram.com/tcu_setagayafes",
-    facebook: "https://facebook.com/tcu.setagayafes",
+    twitter: "https://x.com/setagayafes_tcu?s=11",
+    instagram: "https://www.instagram.com/setagayafes_sfa?igsh=bWpzYWpqOGozZ3Nr&utm_source=qr",
+    youtube: "https://youtube.com/@setagayafes?si=WvB8ya5RrqvHg0Vj",
   },
 
   // メタデータ


### PR DESCRIPTION
## Summary
- `siteConfig.sns` のX/Instagramを新URLに更新し、facebookキーをyoutubeへ差し替え
- `aboutConfig.social` にもYouTubeを追加、X/InstagramのURLを統一
- `SocialIcons` / `StaggeredMobileMenu` のFacebookアイコン・リンクをYouTubeに置換

## Test plan
- [x] `tsc --noEmit` エラーなし
- [x] `pnpm lint` エラー0件
- [ ] 実機でヘッダー/フッター/委員会ページのSNSリンク遷移確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)