### PR TITLE
CI: docs/refactor ブランチと dev 宛て PR をチェック対象に追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,17 @@ refactor/<refactor-target> # リファクタリング
 - `feature/3d-campus-map`
 - `bugfix/countdown-timer-fix`
 
+**CI のカバー範囲:**
+
+`.github/workflows/feature-ci.yml`（Lint & Format Check / Build Check）は次の場合に走る。**上記5つの命名規則から外れたブランチ名を使うと、push 時のチェックが一切走らない。**
+
+| イベント       | 対象                                                             |
+| -------------- | ---------------------------------------------------------------- |
+| `push`         | `feature/**`, `bugfix/**`, `hotfix/**`, `docs/**`, `refactor/**` |
+| `pull_request` | base が `main` または `dev`                                      |
+
+push 時は head をそのまま、PR 時は head を base へマージした結果を検証する。**両方走る場合、それは重複ではなく別種の検証である。**
+
 ### コミットメッセージ規約
 
 **基本フォーマット:**

--- a/.github/workflows/feature-ci.yml
+++ b/.github/workflows/feature-ci.yml
@@ -1,14 +1,21 @@
 name: Feature Branch CI
 
+# トリガは .claude/CLAUDE.md のブランチ命名規則とマージ経路（作業ブランチ → dev → main）に対応させる。
+# push は作業ブランチへの直接の変更を、pull_request は base へマージした結果を検証する。
+# 両方が走るケースでは検証対象が異なる（前者は head、後者は head を base へマージしたもの）ため、
+# 重複ではなく別種の検証として扱う。
 on:
   push:
     branches:
       - "feature/**"
       - "bugfix/**"
       - "hotfix/**"
+      - "docs/**"
+      - "refactor/**"
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   lint-and-format:


### PR DESCRIPTION
Follows #52

## 何が起きていたか

`feature-ci.yml` のトリガが、**プロジェクトのブランチ命名規則と実際のマージ経路のどちらもカバーしていませんでした。**

```yaml
# 修正前
on:
  push:
    branches: ["feature/**", "bugfix/**", "hotfix/**"]
  pull_request:
    branches: [main]
```

| 漏れ | 影響 |
| --- | --- |
| push に `docs/**` / `refactor/**` がない | `.claude/CLAUDE.md` が命名規則として定義しているのに、CI が拾わない |
| pull_request が `main` 宛てだけ | 実際の運用は「作業ブランチ → `dev` → `main`」。**日常的なマージのほとんどが Lint / Build を通らずに `dev` へ入っていた** |

#52（`docs/link-issue-51` → `dev`）で **Vercel 以外のチェックが1件も走らなかった**ことで判明しました。

#50 にチェックが付いていたのは head が `bugfix/**` で **push トリガを踏んだため**であり、`dev` 宛て PR だったからではありません。つまり、これまで `dev` 宛て PR に付いていたチェックはすべて偶然の産物です。

## 変更内容

```yaml
# 修正後
on:
  push:
    branches: ["feature/**", "bugfix/**", "hotfix/**", "docs/**", "refactor/**"]
  pull_request:
    branches: [main, dev]
```

あわせて `.claude/CLAUDE.md` のブランチ戦略節へ CI のカバー範囲表を追加し、**命名規則から外れたブランチ名を使うと push 時のチェックが一切走らない**ことを警告として明記しました。

## 設計判断

**push と pull_request の両方が走るケースを、重複として抑制しません。**

- `push` は head をそのまま検証する
- `pull_request` は head を base へマージした結果を検証する

後者は前者が原理的に検出できない統合時の破綻を捕まえます。検証対象が異なるため重複ではありません。公開リポジトリで Actions の実行時間は無料なので、`concurrency` による実行抑制も入れていません。

## 検証

- [x] `pnpm format:check` 通過
- [x] `on:` ブロックのパース結果を確認（`push.branches` 5件、`pull_request.branches` 2件、jobs は `lint-and-format` / `build` の2つで変更なし）
- [ ] **この PR 自体が生きた検証になります。** head が `bugfix/**` なので push トリガで、base が `dev` なので新しい pull_request トリガで、**Lint & Format Check と Build Check が両方走るはず**です。走らなければ修正が効いていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
