### PR TITLE
DOC: todo.md の技術スタック行を歯車演出の稼働と整合させる

### DIFF
--- a/docs/requires/todo.md
+++ b/docs/requires/todo.md
@@ -7,7 +7,7 @@
 - **開催日程**: 2026年10月31日（土）〜11月1日（日）
 - **公開予定**: 2026年2月28日
 - **開発期間**: 約3ヶ月（2025年12月〜2026年2月）
-- **技術スタック**: Next.js 16.1 (App Router), TypeScript, TailwindCSS, GSAP, microCMS, next-intl, Vercel（Three.js は 3Dマップ見送りにより不使用）
+- **技術スタック**: Next.js 16.1 (App Router), TypeScript, TailwindCSS, GSAP, Three.js / React Three Fiber, microCMS, next-intl, Vercel（Three.js は 3Dマップでは不採用。カラクリの歯車演出 `src/components/three/` で稼働中 — Phase 3 の見送り節を参照）
 
 ## 進捗状況
 


### PR DESCRIPTION
## 概要

`docs/requires/todo.md` 冒頭の技術スタック行が **「Three.js は 3Dマップ見送りにより不使用」** と宣言していたが、PR #56 の `1096dba` でカラクリの歯車演出を復活させたため、マージ時点で事実に反していた。

## 何が矛盾していたか

同一ファイル内で正反対のことを書いていた。

| 箇所 | 記述 |
| --- | --- |
| `todo.md:10`（サマリ） | Three.js は **不使用** |
| `todo.md:203` 付近（Phase 3 見送り節） | `three` / `@react-three/fiber` は `src/components/three/` が使用。**現在はクライアントチャンクに含まれる**（860K / brotli 185K）。**削除しないこと** |

`docs/` を唯一の SoT とする運用上、サマリ行だけを読んだ者が依存を落とすと `FeaturedEvents` → `FeaturedGearScene` → `GearScene` の解決に失敗する。

## 変更内容

`.claude/CLAUDE.md:22` および `docs/requires/require.md:44` の「3Dマップは見送り。カラクリ演出用に残置」と表現を揃えた。

```diff
- ...GSAP, microCMS, next-intl, Vercel（Three.js は 3Dマップ見送りにより不使用）
+ ...GSAP, Three.js / React Three Fiber, microCMS, next-intl, Vercel
+ （Three.js は 3Dマップでは不採用。カラクリの歯車演出 `src/components/three/` で稼働中 — Phase 3 の見送り節を参照）
```

## 検証

- `pnpm format:check` 通過
- `docs/` と `.claude/CLAUDE.md` の全 Three.js 記述を横断確認し、矛盾ゼロを確認
- チェックボックス集計（137 / 143・95.8%）には影響なし

## 経緯

PR #56 のレビューで検出。同レビューで挙がった #51 チェックボックスと進捗サマリの更新は、PR #55（`4bcb593`）で対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)