### PR TITLE
FIX: 歯車のチルト判定を Tailwind md と相補にする

### DIFF
--- a/src/components/home/FeaturedEvents.tsx
+++ b/src/components/home/FeaturedEvents.tsx
@@ -32,8 +32,10 @@ export async function FeaturedEvents() {
         チルトしない。一方モバイルではチルト自体を無効化しており、有効にしても
         ポインタ座標を拾うだけ無駄なので none で固定する。
 
-        しきい値は Gear.tsx の isMobile（max-width: 768px）と対にすること。
-        ずらすと「チルトは有効なのにポインタ座標が来ない」帯域ができる。
+        しきい値は Gear.tsx の isMobile（max-width: 767.98px）と対にすること。
+        md は min-width: 768px なので、isMobile 側を 768px にすると 768px ちょうど
+        （iPad ポートレート）で両方成立し、pointer-events だけ有効な帯域ができる。
+        逆にずらすと「チルトは有効なのにポインタ座標が来ない」帯域ができる。
 
         この指定が効くのは GearScene が Canvas へ pointerEvents: "inherit" を
         渡しているからで、外すと R3F 既定の auto が復活して none が無効になる。

--- a/src/components/three/Gear.tsx
+++ b/src/components/three/Gear.tsx
@@ -20,7 +20,10 @@ export function Gear(props: ThreeElements["group"]) {
   const groupRef = useRef<Group>(null);
   const gearGeometry = useMemo(() => createGearGeometry(), []);
   const hubGeometry = useMemo(() => createHubRingGeometry(), []);
-  const isMobile = useMediaQuery("(max-width: 768px)");
+  // Tailwind の md（min-width: 768px）と相補にする。768px ちょうどで両方成立させないため
+  // 上限を 767.98px にしている。ここをずらすと FeaturedEvents の md:pointer-events-auto と
+  // 食い違い、「チルトは有効なのにポインタ座標が来ない」帯域ができる。
+  const isMobile = useMediaQuery("(max-width: 767.98px)");
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   useFrame((state, delta) => {


### PR DESCRIPTION
PR #58 の事後レビューで検出した Low 1 件を修正します。

## 問題

`Gear.tsx` の `isMobile` は `max-width: 768px`、`FeaturedEvents` の `md:pointer-events-auto` は `min-width: 768px` なので、**768px ちょうどで両方成立**します。この幅では pointer-events が有効なのにチルトは無効で、Canvas がポインタイベントを拾うだけになります。

768px は iPad ポートレートの CSS 幅そのものなので、机上の 1px 問題ではありません。

PR #58 の `726a892` は「しきい値は `Gear.tsx` の `isMobile`（max-width: 768px）と対にすること」とコメントで宣言していましたが、`min-width` と `max-width` に同じ値を書いた時点で相補になっていませんでした。

| 幅       | `md:pointer-events-auto` | `isMobile` | チルト | 状態                             |
| -------- | ------------------------ | ---------- | ------ | -------------------------------- |
| 767px    | 無効                     | true       | 無効   | 整合                             |
| **768px**| **有効**                 | **true**   | **無効** | **不整合（本 PR の対象）**     |
| 769px    | 有効                     | false      | 有効   | 整合                             |

## 修正

`isMobile` の上限を `767.98px` へ下げて相補にしました。数値だけ直すと次の編集者が `768` へ戻すため、両ファイルのコメントに「なぜ 768 ではないか」を残しています。

- `src/components/three/Gear.tsx` — `(max-width: 768px)` → `(max-width: 767.98px)`
- `src/components/home/FeaturedEvents.tsx` — `726a892` のコメントを実装に合わせて訂正

## 実害の有無

**観測可能な不具合はありません。** Canvas は `z-0` で本文（`z-10`）の背面にあり、重なる領域に操作要素はありません。R3F v9 は canvas へ `touch-action` を付けないため、768px のタッチ端末でスクロールを奪うこともありません。

修正の目的は `726a892` と同じく、**コメントが説明している仕組みを実際に成立させること**です。

## 既知の制約

この修正は既定フォントサイズ 16px を前提にしています。Tailwind v4 の `md` は `48rem` 指定で、メディアクエリ内の `rem` はブラウザの既定フォントサイズに解決されるため、利用者が既定を 20px にすると `md` は 960px へ動く一方 `767.98px` は動かず、768〜960px に「チルト有効・ポインタ座標なし」の帯域が復活します。

完全に相補にするなら `(width < 48rem)` ですが、レンジ構文は Safari 16.4+ を要求します（Tailwind v4 自体が同じ要求なので実質的な追加制約はありません）。今回は px 指定のまま据え置き、必要になった時点で切り替える判断です。

## 検証

- [x] `pnpm format:check` 通過
- [x] `pnpm lint` — 0 errors / 13 warnings（すべて本 PR 非関連の既存指摘。件数は PR #58 時点から変化なし）
- [x] husky + lint-staged 通過
- [x] **実機 Chrome で確認**（ローカル本番ビルド `NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build && pnpm start`）

### 境界の実測（同一オリジン iframe で viewport 幅を厳密に固定）

ウィンドウリサイズは viewport へ反映されないことがあるため、`localhost:3000` を同一オリジンの iframe に読み込み、`iframe.contentWindow` 側で `matchMedia` と `getComputedStyle` を読みました。

| 幅        | `(width >= 48rem)` | ラッパーの `pointer-events` | `(max-width: 768px)` 旧 | `(max-width: 767.98px)` 新 | 旧チルト | 新チルト   |
| --------- | ------------------ | --------------------------- | ----------------------- | -------------------------- | -------- | ---------- |
| 767px     | `false`            | `none`                      | `true`                  | `true`                     | 無効     | 無効       |
| **768px** | `true`             | **`auto`**                  | **`true`**              | **`false`**                | **無効** | **有効**   |
| 769px     | `true`             | `auto`                      | `false`                 | `false`                    | 有効     | 有効       |

768px の行が本 PR の対象です。旧値では `pointer-events` だけ有効でチルトが無効という不整合が実測で再現し、新値で解消することを確認しました。横スクロールバーは 767 / 768 / 769 のいずれでも発生しません。

### PR #58 の積み残し 6 項目も同時に消化

| 項目                                    | 結果                                                                                                                                    |
| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| 歯車が描画され回転している              | ✅ 4 秒間隔の 2 枚で歯の位置が明確に変化                                                                                                 |
| スピナーが出ない                        | ✅ `document.querySelectorAll('.animate-spin').length === 0`（ロード直後の iframe でも 0）                                               |
| `pointerEvents: "inherit"` が効いている | ✅ R3F ルート div の実インライン style が `position: relative; width: 100%; height: 100%; overflow: hidden; pointer-events: inherit;`     |
| ポインタが Canvas へ届く                | ✅ ルート div の `pointermove` が 2 回発火。負の対照としてラッパーを `pointer-events: none` にすると 0 回（継承チェーンが効いている証拠） |
| モーション軽減の対象                     | ✅ 配信 CSS の `@media (prefers-reduced-motion: reduce)` に `.animate-spin-slow` が入り、素の `.animate-spin` は入っていない              |
| 横スクロールバーが出ない                | ✅ `scrollWidth === clientWidth`                                                                                                          |

> [!NOTE]
> **残り 1 項目**: OS のモーション軽減設定を実際に ON にしたときの静止確認。ブラウザからは `prefers-reduced-motion` を強制できないため、macOS の システム設定 → アクセシビリティ → ディスプレイ → 視差効果を減らす を切り替えての確認が必要です。配信 CSS にルールが入っていることと、`useMediaQuery` が初回レンダーで `matchMedia` を読むことは確認済みなので、残っているのは目視のみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
