### PR TITLE
DOC: promoteを使わない理由とAliased表示の限界・公開ドメインの確認手順を追記

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -105,7 +105,9 @@ docs/
   - 企画・お知らせの公開フラグと非公開時の表示範囲
   - ワークフローでの参照方法（`secrets.` vs `vars.`）
   - ローカル開発（.env.local）との対応表
-  - **Vercel の本番反映は手動 Promote。** main へ merge しても Production は作られない（Preview のみ）。完了は Production デプロイの sha と main 先端の一致で判定する
+  - **Vercel の本番反映は手動。** main へ merge しても Production は作られない（Preview のみ）。完了は Production デプロイの sha と main 先端の一致で判定する
+  - **`vercel promote` は使わない。** 再ビルドしないため Preview 環境変数の成果物が本番に出る（`MICROCMS_SERVICE_DOMAIN` は環境別）。`vercel redeploy --target production` を使う
+  - **`Aliased:` 表示は DNS を保証しない。** 公開ドメインは `curl -sI` の `server` / `location` ヘッダで実応答を確認する。`NEXT_PUBLIC_URL` のホストが名前解決できるかも確認する
 
 - **[microcms.md](./dev/microcms.md)** - microCMS API 制約と実装パターン
   - limit 上限100件の制約と offset ページネーション実装

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -80,10 +80,12 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 - どちらも `true` の場合のみ公開する。未設定または `true` 以外は安全側として非公開になる。
 - ビルド時に評価されるため、値を変更した後は再ビルド・再デプロイが必要。
 
-## Vercel の本番反映は手動 Promote
+## Vercel の本番反映は手動
 
 > [!IMPORTANT]
-> **`main` へ merge しても Production デプロイは作られません。** 作られるのは Preview だけで、Production は人手で Promote する運用です。**「merge したから本番に出ている」と思い込まないでください。**
+> **`main` へ merge しても Production デプロイは作られません。** 作られるのは Preview だけで、Production は人手で作る運用です。**「merge したから本番に出ている」と思い込まないでください。**
+>
+> 操作は `vercel promote` **ではなく** `vercel redeploy --target production` です（理由は後述）。
 
 実測した挙動です。
 
@@ -94,7 +96,7 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 | `c90f980` | 2026-08-09 21:53 | （作られないまま次の merge へ） | —        |
 | `3f9f0fb` | 2026-08-09 22:12 | 2026-08-09 22:30                | 18分後   |
 
-**すべてのコミットがまず Preview になり、Production は後から別途作られています。** 遅延が push と無相関で、`c90f980` のように Promote されないまま次のリリースに追い越される場合もあります。
+**すべてのコミットがまず Preview になり、Production は後から別途作られています。** 遅延が push と無相関で、`c90f980` のように本番反映されないまま次のリリースに追い越される場合もあります。
 
 ### 完了判定
 
@@ -108,12 +110,67 @@ git ls-remote origin refs/heads/main | cut -f1
 
 `vercel ls <project> --prod` でも Production デプロイの履歴を確認できます。`vercel inspect <url>` の `target` が `production` かどうかが正準です。
 
+### `vercel promote` は使わない
+
+> [!CAUTION]
+> **`vercel promote` を本番反映に使ってはいけません。** `promote` は**再ビルドせず**エイリアスを張り替えるだけなので、**Preview 環境変数でビルドされた成果物が本番に出ます。**
+
+本プロジェクトは同名の環境変数を環境ごとに別値で登録しています。`vercel env ls` の `environments` 列で確認できます。
+
+| 変数                         | 登録状況                                     |
+| ---------------------------- | -------------------------------------------- |
+| `MICROCMS_SERVICE_DOMAIN`    | **Production と Preview で別行＝別値**       |
+| `MICROCMS_API_KEY`           | Production, Preview で共有／Development は別 |
+| `NEXT_PUBLIC_EVENTS_VISIBLE` | Production, Preview で共有                   |
+
+`MICROCMS_SERVICE_DOMAIN` が環境別なので、`promote` すると **Preview の microCMS サービスから取得したコンテンツが本番に出ます。** 正しい操作は Production 環境変数での再ビルドです。
+
+```bash
+# main のマージコミットに対応する deployment URL を GitHub Deployments API から引く
+DID=$(gh api "repos/<owner>/<repo>/deployments?per_page=5" --jq '.[] | select(.sha=="<main の sha>") | .id' | head -1)
+gh api "repos/<owner>/<repo>/deployments/$DID/statuses" --jq '.[0].target_url'
+
+# その deployment を Production 環境変数で再ビルドする
+vercel redeploy <上で得た URL> --target production
+```
+
+過去の Production デプロイが「Preview の十数分後に別レコードとして現れる」のは、この再ビルドが行われているためです。
+
+### 公開ドメインの確認
+
+> [!IMPORTANT]
+> **`vercel redeploy` の出力に出る `Aliased: https://...` は、そのドメインが実際にこのデプロイを指していることを保証しません。** DNS が Vercel を向いていなければエイリアスは実効しません。
+
+Vercel の表示を信じず、実際の応答で確認してください。
+
+```bash
+# リダイレクトを追跡して最終的な到達先を見る
+curl -s -o /dev/null -L -w "%{http_code} %{url_effective} (ip=%{remote_ip})\n" https://<公開ドメイン>
+
+# server ヘッダが Vercel でなければ、DNS は別のホストを向いている
+curl -sI https://<公開ドメイン> | grep -iE "^(server|location):"
+```
+
+`NEXT_PUBLIC_URL` に設定したホストが**そもそも名前解決できるか**も確認します。解決できないと `robots.txt` の `Sitemap:` 行、`sitemap.xml`、OGP・canonical のすべてが存在しないホストを指します。
+
+```bash
+# 環境が dig / host を禁止している場合は公開 DoH で引く（Status=3 は NXDOMAIN）
+curl -s "https://dns.google/resolve?name=<host>&type=A" | python3 -m json.tool
+```
+
+`NEXT_PUBLIC_URL` の値そのものは、本番デプロイの `robots.txt` から読み取れます。
+
+```bash
+curl -s https://<production deployment url>/robots.txt | grep Sitemap
+```
+
 ### RELEASE PR のチェックリスト
 
 `dev` → `main` の PR には次を含めてください。
 
-1. merge 後に Promote が必要である旨（**変動する sha は書かない。すぐ陳腐化する**）
+1. merge 後に本番反映（`vercel redeploy --target production`）が必要である旨（**変動する sha は書かない。すぐ陳腐化する**）
 2. 上記の完了判定コマンド
+3. 公開ドメインが当該デプロイを指しているかの確認
 
 ## 注意事項
 

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -130,11 +130,28 @@ git ls-remote origin refs/heads/main | cut -f1
 DID=$(gh api "repos/<owner>/<repo>/deployments?per_page=5" --jq '.[] | select(.sha=="<main の sha>") | .id' | head -1)
 gh api "repos/<owner>/<repo>/deployments/$DID/statuses" --jq '.[0].target_url'
 
-# その deployment を Production 環境変数で再ビルドする
+# その deployment を Production ターゲットで再ビルドする
 vercel redeploy <上で得た URL> --target production
 ```
 
 過去の Production デプロイが「Preview の十数分後に別レコードとして現れる」のは、この再ビルドが行われているためです。
+
+#### `redeploy` は環境変数を「元デプロイの値」で再現する
+
+> [!CAUTION]
+> **`vercel redeploy` は元デプロイの環境変数スナップショットを再利用します。** 再ビルドはしますが、**再ビルド後に変更した環境変数は反映されません。** `redeploy` は「過去のデプロイを再現する」ためのコマンドだからです。
+
+実測です。`NEXT_PUBLIC_URL` を Production で更新したあと、更新前に作られた deployment を `redeploy --target production` したところ、ビルドは走ったのに `robots.txt` の `Sitemap:` 行は**古い値のまま**でした。`vercel env pull --environment=production` で確認すると、変数自体は新しい値になっていました。
+
+`NEXT_PUBLIC_*` はビルド時にバンドルへ埋め込まれるため、この差は静的な出力にそのまま残ります。
+
+**環境変数を変えたときは、変更後に作られた deployment を対象にしてください。**
+
+| 状況                       | 正しい手順                                                           |
+| -------------------------- | -------------------------------------------------------------------- |
+| コードだけ変わった         | main のマージコミットの deployment を `redeploy --target production` |
+| **環境変数を変えた**       | **変更後に新しい commit を push し、その deployment を redeploy**    |
+| 変更を反映したか確かめたい | `curl -s <deployment url>/robots.txt \| grep Sitemap` で実出力を見る |
 
 ### 公開ドメインの確認
 


### PR DESCRIPTION
前回の本番反映作業で実際に踏んだ3点を `docs/dev/ci-env.md` へ記録します。コード変更はありません。

## 1. `vercel promote` を使ってはいけない

**`promote` は再ビルドせずエイリアスを張り替えるだけ**で、Preview 環境変数でビルドされた成果物が本番に出ます。

本プロジェクトは同名の環境変数を環境ごとに別値で登録しています（`vercel env ls` の `environments` 列）。

| 変数 | 登録状況 |
| --- | --- |
| `MICROCMS_SERVICE_DOMAIN` | **Production と Preview で別行＝別値** |
| `MICROCMS_API_KEY` | Production, Preview で共有／Development は別 |
| `NEXT_PUBLIC_EVENTS_VISIBLE` | Production, Preview で共有 |

`MICROCMS_SERVICE_DOMAIN` が環境別なので、`promote` すると **Preview の microCMS サービスから取得したコンテンツが本番に出ます。** 正しい操作は `vercel redeploy --target production`（Production 環境変数で再ビルド）です。deployment URL を GitHub Deployments API から引く手順も併記しました。

過去の Production デプロイが「Preview の十数分後に別レコードとして現れる」のは、この再ビルドが行われていたためです。

## 2. `Aliased:` 表示は DNS を保証しない

`vercel redeploy` の出力は `Aliased: https://www.setagayafes.org` と表示しますが、実際に `curl` すると **`server: nginx` が 302 を返します。** DNS が Vercel を向いていないためエイリアスが実効していません。

`curl -sI` の `server` / `location` ヘッダで実応答を確認する手順を記載しました。

## 3. `NEXT_PUBLIC_URL` のホストの名前解決確認

解決できないと `robots.txt` の `Sitemap:` 行、`sitemap.xml`、OGP・canonical の**すべてが存在しないホストを指します。**

`dig` / `host` が環境側で REFUSED される場合の公開 DoH での引き方と、`robots.txt` から実値を読み取る方法を記載しました。

## その他

- 見出しの「手動 Promote」は `promote` を使わない方針と衝突するため「手動」へ改めた
- RELEASE PR のチェックリストに「公開ドメインが当該デプロイを指しているかの確認」を追加
- `docs/INDEX.md` の索引も同内容で更新（`AGENTS.md` の必須ルール）

## 検証

- [x] `pnpm format:check` 通過
- [x] 相対リンク（`./git.md`）の到達性を確認
- [x] コード変更なし（`docs/` 配下 2 ファイルのみ）
- [x] 用語の衝突（「手動 Promote」の残存）を grep で確認・解消

> [!WARNING]
> 本 PR は手順を記録するものですが、**その手順で調べた結果、未解決の本番課題が1件見つかっています。** `NEXT_PUBLIC_URL` が指す `setagayafes97.tcu.ac.jp` が **NXDOMAIN** です（公開 DoH で `Status=3`）。対応は本 PR の範囲外で、DNS 側の判断が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
