### PR TITLE
FEATURE: 第96回アーカイブへの301リダイレクトとドメイン移行手順を追加

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@ docs/
 ├── dev/              # 開発関連ドキュメント
 │   ├── git.md        # ブランチ戦略とCI/CDワークフロー
 │   ├── ci-env.md     # GitHub Actions 環境変数管理（Secrets/Variables）
+│   ├── domain-migration.md # setagayafes.org を第97回の正規ドメインにする手順
 │   └── microcms.md   # microCMS API 制約と実装パターン
 ├── frontend/         # フロントエンド関連ドキュメント
 │   ├── design.md                  # デザインシステム（カラー・タイポグラフィトークン）
@@ -106,6 +107,12 @@ docs/
   - ワークフローでの参照方法（`secrets.` vs `vars.`）
   - ローカル開発（.env.local）との対応表
   - **Vercel の本番反映は手動 Promote。** main へ merge しても Production は作られない（Preview のみ）。完了は Production デプロイの sha と main 先端の一致で判定する
+
+- **[domain-migration.md](./dev/domain-migration.md)** - `setagayafes.org` を第97回の正規ドメインにする手順
+  - 第96回（WordPress）は `96th.setagayafes.org` へ退避し、`/96th/*` は 301 で引き継ぐ
+  - **rewrite プロキシは採らない。** trailing-slash リダイレクトが rewrite より先に走るため無限ループになり、`skipTrailingSlashRedirect` で止めると canonical 未実装の現状で重複URLを生む
+  - 手順の順序（WordPress の `siteurl` 変更 → 301 の本番反映 → DNS 切替）と各段階の検証コマンド
+  - Vercel が要求する DNS レコード（`A 76.76.21.21` / `CNAME cname.vercel-dns.com`）
 
 - **[microcms.md](./dev/microcms.md)** - microCMS API 制約と実装パターン
   - limit 上限100件の制約と offset ページネーション実装

--- a/docs/dev/domain-migration.md
+++ b/docs/dev/domain-migration.md
@@ -1,0 +1,124 @@
+# ドメイン移行（setagayafes.org を第97回の正規ドメインにする）
+
+`setagayafes.org` を第97回サイトの正規ドメインとして公開し、第96回サイトはサブドメインへ退避する。本ドキュメントは決定内容・現状・手順・検証方法を記録する。
+
+## 決定
+
+| 項目                 | 内容                                                          |
+| -------------------- | ------------------------------------------------------------- |
+| 第97回の正規ドメイン | **`setagayafes.org`**（apex）                                 |
+| 第96回の退避先       | **`96th.setagayafes.org`**（さくらに残す）                    |
+| 旧URLの扱い          | `setagayafes.org/96th/*` → **301** → `96th.setagayafes.org/*` |
+| `NEXT_PUBLIC_URL`    | `https://setagayafes.org`                                     |
+
+## 現状（未了）
+
+> [!WARNING]
+> **DNS のカットオーバーは未実施。** `setagayafes.org` はさくらを向いており、第96回サイトを配信している。第97回サイトは Vercel のデプロイURLでのみ到達できる。
+
+| 項目                            | 状態                                                         |
+| ------------------------------- | ------------------------------------------------------------ |
+| Vercel のドメイン割当           | **完了**（`setagayafes.org` / `www.setagayafes.org` の両方） |
+| `NEXT_PUBLIC_URL`               | **完了**（Vercel / GitHub Variables とも `setagayafes.org`） |
+| `/96th/*` の 301                | **実装済み**（`next.config.ts`）                             |
+| `96th.setagayafes.org` の作成   | **未了**（さくら側の作業）                                   |
+| WordPress の `siteurl` / `home` | **未了**（さくら側の作業）                                   |
+| `setagayafes.org` の DNS 切替   | **未了**（さくら側の作業）                                   |
+
+## なぜ rewrite ではなく redirect なのか
+
+当初は `setagayafes.org/96th/` の URL を保つため Vercel の rewrite でさくらへプロキシする方針だった。**アーカイブの実体が WordPress だと判明した時点で撤回した。**
+
+### 理由1: 無限リダイレクトループになる
+
+Next.js の trailing-slash リダイレクトは **rewrite より先**に走る。
+
+```
+/96th/  → Next が 308 → /96th  → rewrite → さくら 301 → /96th/  → …
+```
+
+`skipTrailingSlashRedirect: true` で止められるが、サイト全体の trailing-slash 正規化が効かなくなる。本プロジェクトは `alternates.canonical` を実装していないため、`/events` と `/events/` の両方が 200 を返す重複URLが生まれる。
+
+### 理由2: Vercel の帯域を消費する
+
+WordPress の全アセット（画像・CSS・JS）が Vercel を経由する。Free Plan の帯域は 100GB/月で、アーカイブのために払うコストではない。
+
+## 実測した現状（2026-08-15 時点）
+
+```
+setagayafes.org        → 49.212.207.29（さくら）  302 → /96th/
+www.setagayafes.org    → 133.167.31.34（さくら）  302 → /96th/
+setagayafes.org/96th   → 301 → /96th/
+setagayafes.org/96th/  → 200（WordPress）
+setagayafes.org/95th/  → 404
+NS                     → ns1.dns.ne.jp / ns2.dns.ne.jp
+```
+
+第96回サイトは WordPress（`wp-json` / `xmlrpc.php` / `feed/` を確認）。内部リンクはすべて `https://setagayafes.org/96th/...` の絶対URL。
+
+## 手順
+
+**順序を守ること。** 逆順で実施すると第96回サイトが一時的に到達不能になる。
+
+### ステップ1: 第96回を新ホストへ（さくら側）
+
+1. `96th.setagayafes.org` の DNS レコードを作成し、現在の第96回サーバへ向ける
+2. さくら側でこのホストのドキュメントルートを **WordPress のディレクトリ**へ向ける
+   - `96th.setagayafes.org/` で WordPress のトップが出る状態にする
+   - `96th.setagayafes.org/96th/` ではない
+3. WordPress の `siteurl` / `home` を `https://96th.setagayafes.org` へ変更する
+   - **これを怠ると WordPress が絶対URLで `setagayafes.org/96th/` を出し続け、ステップ3 の 301 へ戻ってループする**
+
+検証:
+
+```bash
+curl -s -o /dev/null -L -w "%{http_code} %{url_effective}\n" https://96th.setagayafes.org/
+curl -s https://96th.setagayafes.org/ | grep -o 'href="https://[^"]*"' | head -5
+# href が 96th.setagayafes.org を指していること
+```
+
+### ステップ2: 301 を本番へ反映
+
+`next.config.ts` の `redirects()` は実装済み。dev → main の RELEASE を通して本番反映する（手順は [ci-env.md](./ci-env.md) の「Vercel の本番反映は手動」）。
+
+DNS 切替前なので、この時点では `setagayafes.org` はさくらを向いたままであり、この 301 は経路に入らない。**先に入れておいて問題ない。**
+
+### ステップ3: DNS を Vercel へ切り替え
+
+Vercel が要求するレコードは次のとおり。
+
+```
+A      setagayafes.org       76.76.21.21
+CNAME  www.setagayafes.org   cname.vercel-dns.com
+```
+
+`vercel domains inspect setagayafes.org` で `Intended Nameservers` と検証状況を確認できる。ネームサーバごと Vercel へ移す方法もあるが、`96th.setagayafes.org` を含む他のレコードをさくらで管理し続けるなら A / CNAME 追加のほうが影響が小さい。
+
+### ステップ4: 検証
+
+```bash
+# 第97回が出ること
+curl -s -o /dev/null -L -w "%{http_code} %{url_effective}\n" https://setagayafes.org/
+curl -sI https://setagayafes.org/ | grep -i '^server:'   # Vercel であること
+
+# 旧URLが 301 で引き継がれること
+curl -s -o /dev/null -L -w "%{http_code} %{url_effective}\n" https://setagayafes.org/96th/
+
+# canonical / sitemap が正規ドメインを指すこと
+curl -s https://setagayafes.org/robots.txt | grep Sitemap
+```
+
+## 注意
+
+- **`NEXT_PUBLIC_URL` はビルド時にバンドルへ埋め込まれる。** 値を変えたら、変更後に作られた deployment を本番へ反映すること（[ci-env.md](./ci-env.md) の「`redeploy` は環境変数を『元デプロイの値』で再現する」）
+- `setagayafes.org` と `www.setagayafes.org` は両方 Vercel プロジェクトへ割当済み。どちらを正規にするかは Vercel の Domains 設定で決まる。**apex を正規とし、www は apex へリダイレクトする**方針
+- 第95回は既に 404。過去回のアーカイブ運用は第96回のみ
+
+## 関連ドキュメント
+
+- [ci-env.md](./ci-env.md) — 環境変数と本番反映の手順
+- [git.md](./git.md) — ブランチ戦略と CI/CD ワークフロー
+
+---
+
+**最終更新日**: 2026-08-15

--- a/docs/dev/domain-migration.md
+++ b/docs/dev/domain-migration.md
@@ -43,6 +43,26 @@ Next.js の trailing-slash リダイレクトは **rewrite より先**に走る�
 
 WordPress の全アセット（画像・CSS・JS）が Vercel を経由する。Free Plan の帯域は 100GB/月で、アーカイブのために払うコストではない。
 
+## 301 の実測挙動
+
+Preview デプロイで確認した結果（`96th.setagayafes.org` はまだ存在しないため、最終ホップは名前解決に失敗する）。
+
+| リクエスト      | ホップ | 最終到達先                            |
+| --------------- | ------ | ------------------------------------- |
+| `/96th`         | 1      | `https://96th.setagayafes.org/`       |
+| `/96th/`        | **2**  | `https://96th.setagayafes.org/`       |
+| `/96th/access/` | **2**  | `https://96th.setagayafes.org/access` |
+| `/96th/?q=1`    | **2**  | `https://96th.setagayafes.org/?q=1`   |
+
+パスもクエリも正しく引き継がれる。
+
+**末尾スラッシュつきのURLは 2 ホップになる。** `trailingSlash: false`（既定）のため Next.js がまず `/96th/` → `/96th` へ正規化し、そのあと 301 が走るためである。1 ホップにするにはサイト全体の `trailingSlash` 方針を変える必要があり、割に合わない。
+
+また `/96th/access/` は `/access`（末尾スラッシュなし）へ引き継がれるため、移行先の WordPress が `/access` → `/access/` へ 301 する場合は合計 3 ホップになる。実用上の問題はない。
+
+> [!NOTE]
+> `permanent: true` は **308** を返す。本プロジェクトは `statusCode: 301` を明示している。308 の検索エンジンでの扱いは 301 と同等だが、古いクローラやリンクチェッカには 301 のほうが確実に伝わるためである。アーカイブへの GET 導線に method 保持（308 の利点）は不要。
+
 ## 実測した現状（2026-08-15 時点）
 
 ```

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,7 +39,13 @@ const nextConfig: NextConfig = {
       {
         source: "/96th/:path*",
         destination: `${ARCHIVE_96TH_ORIGIN}/:path*`,
-        permanent: true,
+        /*
+         * `permanent: true` ではなく `statusCode: 301` を指定する。
+         * `permanent: true` は 308 を返す。308 は method を保持する仕様で、
+         * 検索エンジンの扱いは 301 と同等だが、古いクローラやリンクチェッカには
+         * 301 のほうが確実に伝わる。アーカイブへの GET 導線に method 保持は不要。
+         */
+        statusCode: 301,
       },
     ];
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,42 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+/**
+ * 第96回サイトのアーカイブ先。
+ *
+ * `setagayafes.org` は第97回の正規ドメインになるため、第96回の WordPress は
+ * このサブドメインへ退避する。旧URL `setagayafes.org/96th/*` は被リンクが残るので
+ * 301 で引き継ぐ。
+ *
+ * IMPORTANT: rewrite（プロキシ）ではなく redirect である。理由は2つ。
+ *
+ * 1. プロキシにすると無限ループになる。Next.js の trailing-slash リダイレクトは
+ *    rewrite より先に走るため `/96th/` が `/96th` へ 308 され、オリジンの
+ *    WordPress が `/96th/` へ 301 で戻す。`skipTrailingSlashRedirect: true` で
+ *    止められるが、サイト全体の正規化が効かなくなり canonical 未実装の現状では
+ *    重複URLを生む。
+ * 2. WordPress の全アセットが Vercel を経由し、Free Plan の帯域（100GB/月）を
+ *    消費する。アーカイブのために払うコストではない。
+ *
+ * 前提: さくら側で `96th.setagayafes.org` のドキュメントルートを WordPress の
+ * ディレクトリへ向け、WordPress の `siteurl` / `home` も同ホストへ変更しておくこと。
+ * これを怠ると、WordPress が絶対URLで `setagayafes.org/96th/` を出し続けるため
+ * この 301 へ戻ってループする。
+ *
+ * 手順と検証は docs/dev/domain-migration.md を参照。
+ */
+const ARCHIVE_96TH_ORIGIN = "https://96th.setagayafes.org";
+
 const nextConfig: NextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/96th/:path*",
+        destination: `${ARCHIVE_96TH_ORIGIN}/:path*`,
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
`setagayafes.org` を第97回の正規ドメインにするための実装と手順書です。

## 実装: `/96th/*` の 301

```ts
async redirects() {
  return [{
    source: "/96th/:path*",
    destination: "https://96th.setagayafes.org/:path*",
    permanent: true,
  }];
}
```

## rewrite を撤回した理由

当初は URL を保つため Vercel の rewrite でさくらへプロキシする方針でした。**アーカイブの実体が WordPress だと判明した時点で撤回しています**（`wp-json` / `xmlrpc.php` / `feed/` を実測で確認）。

### 理由1: 無限リダイレクトループになる

Next.js の trailing-slash リダイレクトは **rewrite より先**に走ります。

```
/96th/ → Next が 308 → /96th → rewrite → さくら 301 → /96th/ → …
```

実測で `setagayafes.org/96th` が `/96th/` へ 301 することを確認済みです。`skipTrailingSlashRedirect: true` で止められますが、サイト全体の trailing-slash 正規化が効かなくなります。本プロジェクトは `alternates.canonical` を**1件も実装していない**ため、`/events` と `/events/` の両方が 200 を返す重複URLが生まれます。

### 理由2: Vercel の帯域を消費する

WordPress の全アセットが Vercel を経由します。Free Plan の帯域は 100GB/月で、アーカイブのために払うコストではありません。

## 新規ドキュメント: `docs/dev/domain-migration.md`

決定・現状・手順・検証方法を記録しました。

**手順は順序が重要です。**

1. さくら側で `96th.setagayafes.org` を作成し、**WordPress の `siteurl` / `home` を新ホストへ変更**
2. 本 PR の 301 を本番へ反映
3. `setagayafes.org` の DNS を Vercel へ切替（`A 76.76.21.21`）

> [!WARNING]
> **ステップ1の `siteurl` 変更を怠るとループします。** WordPress が絶対URLで `setagayafes.org/96th/` を出し続けるため、この 301 へ戻り続けます。

各ステップの検証コマンドも記載しています。

## 現状（本 PR の範囲外）

| 項目 | 状態 |
| --- | --- |
| Vercel のドメイン割当 | **完了**（159日前から `setagayafes.org` / `www` とも割当済み） |
| `NEXT_PUBLIC_URL` | **完了**（Vercel / GitHub Variables とも `setagayafes.org` へ変更済み） |
| `/96th/*` の 301 | **本 PR** |
| `96th.setagayafes.org` の作成 | 未了（さくら側） |
| WordPress の `siteurl` 変更 | 未了（さくら側） |
| `setagayafes.org` の DNS 切替 | 未了（さくら側） |

DNS 切替前なので、この 301 は経路に入りません。**先に入れておいて問題ありません。**

## 検証

- [x] `npx tsc --noEmit` 通過
- [x] `pnpm format:check` 通過
- [x] `docs/INDEX.md` と `domain-migration.md` の相対リンク到達性を確認
- [x] `docs/INDEX.md` を改訂（`AGENTS.md` の必須ルール）
- [ ] `pnpm build` — **この環境では未実施**

> [!NOTE]
> ローカルの `pnpm build` は Google Fonts の取得に失敗して通りません。**変更を退避したクリーンな状態でも同じ失敗が出る**ことを確認しており、本変更が原因ではありません。CI の Build Check で検証します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
