### PR TITLE
FIX: ヘッダーが lg 幅で窮屈になるのを解消

### DIFF
--- a/src/components/layout/DesktopNav.tsx
+++ b/src/components/layout/DesktopNav.tsx
@@ -19,7 +19,13 @@ interface DesktopNavProps {
 export function DesktopNav({ items }: DesktopNavProps) {
   return (
     <nav className="hidden lg:block">
-      <ul className="flex gap-8">
+      {/*
+        gap は lg 帯だけ詰める。デスクトップナビは lg (1024px) から出るが、
+        実測（2026-08-16）で必要幅は padding 48 + ロゴ 208 + ナビ + 言語切替 90。
+        gap-8 のままだとナビ 674px で合計 1020px となり、1024px での余白が 4px しかない。
+        gap-6 なら 988px となり 36px の余裕ができる。xl 以降は元の間隔へ戻す。
+      */}
+      <ul className="flex gap-6 xl:gap-8">
         {items.map((item) => (
           // key は href ではなく id。href はロケールで変わるため
           <li key={item.id}>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -58,11 +58,22 @@ interface FooterSectionConfig {
 export const navigationConfig = {
   // ヘッダーナビゲーション
   header: [
-    { labelKey: "events", href: "/events" },
-    // 著名人企画は年間の目玉であり、階層を下げると発見されにくい。
+    // 著名人企画は「企画を探す」の子として置く。ヘッダー直下に独立項目として
+    // 並べると、デスクトップナビが出る lg (1024px) の下端で要素が接触するため。
+    //
+    // 実測（2026-08-16 / 1280px）: padding 24×2 + ロゴ 208 + ナビ 766 + 言語切替 90 = 1112px。
+    // 6項目では 1024〜1112px の帯で破綻する（5項目なら 1000px で収まっていた）。
+    //
     // 未解禁（SPECIAL_VISIBLE=false）でも項目は出す。/special は準備中ページとして
     // 成立し、「今年も著名人企画がある」ことを伏せる必要はないため（出演者名は出ない）。
-    { labelKey: "special", href: "/special" },
+    {
+      labelKey: "events",
+      href: "/events",
+      children: [
+        { labelKey: "eventList", href: "/events" },
+        { labelKey: "special", href: "/special" },
+      ],
+    },
     { labelKey: "timetable", href: "/timetable" },
     { labelKey: "access", href: "/access" },
     {

--- a/src/messages/chrome/en.json
+++ b/src/messages/chrome/en.json
@@ -1,6 +1,7 @@
 {
   "navigation": {
     "events": "Events",
+    "eventList": "All Events",
     "special": "Special Guests",
     "timetable": "Timetable",
     "map": "Map & Access",

--- a/src/messages/chrome/ja.json
+++ b/src/messages/chrome/ja.json
@@ -1,6 +1,7 @@
 {
   "navigation": {
     "events": "企画を探す",
+    "eventList": "企画一覧",
     "special": "著名人企画",
     "timetable": "タイムテーブル",
     "map": "マップ・アクセス",

--- a/src/messages/chrome/ko.json
+++ b/src/messages/chrome/ko.json
@@ -1,6 +1,7 @@
 {
   "navigation": {
     "events": "행사 검색",
+    "eventList": "행사 목록",
     "special": "특별 게스트",
     "timetable": "시간표",
     "map": "지도 & 교통",

--- a/src/messages/chrome/zh.json
+++ b/src/messages/chrome/zh.json
@@ -1,6 +1,7 @@
 {
   "navigation": {
     "events": "活动查询",
+    "eventList": "活动一览",
     "special": "特别嘉宾",
     "timetable": "时间表",
     "map": "地图与交通",


### PR DESCRIPTION
#72 / #73 でヘッダーを6項目にしたところ、**デスクトップナビが出る `lg`（1024px）の下端で要素が接触する**ことが実測で判明した。#72 に記した「実機で確認し、窮屈なら案Aへ」の後追い対応。

## 実測（1280px / Vercel preview）

`justify-between` の3ブロックを個別に測った。

| 要素 | 幅 | 位置 |
| --- | --- | --- |
| padding | 24px × 2 | — |
| ロゴ | 208px | 24 → 232 |
| ナビ（6項目 + gap 32px×5） | 766px | 316 → 1082 |
| 言語切替 | 90px | 1166 → 1256 |
| **必要幅の合計** | **1112px** | — |

**デスクトップナビは `hidden lg:block` で 1024px から出る。** つまり **1024〜1112px の帯で破綻する**。5項目時代は 1000px だったため、ぎりぎり成立していた。

## 対処

### 1. 著名人企画を「企画を探す」の子へ（#72 の案A）

```
企画を探す ▾
├── 企画一覧      /events
└── 著名人企画    /special
タイムテーブル
アクセス
インフォメーション
委員会について
```

ヘッダーは5項目に戻る。`info` が既に同じ構造（親もリンク、子の1つ目が親と同じ遷移先）なので、パターンとしては一貫している。

子の1つ目に置く「企画一覧」の翻訳キーを4言語ぶん追加した。

| ja | en | zh | ko |
| --- | --- | --- | --- |
| 企画一覧 | All Events | 活动一览 | 행사 목록 |

### 2. `lg` 帯だけ gap を詰める

**5項目に戻しても必要幅は 1020px で、1024px に対し余白が 4px しかなかった。** これでは実質的に接触しているのと変わらない。

```diff
- <ul className="flex gap-8">
+ <ul className="flex gap-6 xl:gap-8">
```

`lg` 帯（1024〜1279px）は gap 24px で **988px**（36px の余裕）。`xl` 以降は従来の 32px に戻すため、広い画面での見た目は変わらない。

フッターは縦並びのため6項目のまま変更していない。

## 動作確認

- `npx tsc --noEmit` — エラーなし
- `pnpm lint` — エラー 0（警告 13 は既存の `<img>` 由来）
- 4言語の `navigation` キー集合が一致
- ローカル実測で 1280px のナビ幅 674px / gap 32px（`xl:gap-8` が効いている）を確認

> [!NOTE]
> **1024px ちょうどでの目視確認はできていません。** `resize_window` も `agent-browser --viewport` もセッション再利用で viewport が固定され、指定した幅に切り替えられませんでした（この制約は `docs/frontend/agent-browser-workflow.md` に記録済み）。
>
> 上記は 1280px での実測値からの計算です。**36px の余裕を見込んでいますが、1024px 前後で一度目視してください。**

Refs #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)