### PR TITLE
FIX: select フィールドの filters が常に0件を返すのを修正

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -123,6 +123,27 @@ function normalizeEvent(rawEvent: RawEvent): Event {
 const MICROCMS_MAX_LIMIT = 100;
 
 /**
+ * select フィールドは microCMS の filters では絞り込めない
+ *
+ * `[contains]` は select に対して**配列要素の完全一致**で動く。部分一致ではない。
+ * 本プロジェクトの select は `値 : ラベル` 形式（例: `special : スペシャル企画`）で
+ * 登録されているため、値だけを渡すと常に 0 件になる。
+ *
+ * 実測（2026-08-16）:
+ *
+ * | filters                                  | 件数 |
+ * | ---------------------------------------- | ---- |
+ * | `type[contains]special`                  | 0    |
+ * | `type[contains]スペシャル`               | 0    |
+ * | `type[contains]special : スペシャル企画` | 2    |
+ * | `type[equals]special : スペシャル企画`   | 0    |
+ *
+ * ラベルまで含めれば一致するが、**入稿側でラベルを直した瞬間に壊れる**。
+ * したがって select の絞り込みは API に任せず、正規化後の値で filter する。
+ * text フィールド（`building` など）は `[equals]` が正しく動くため API 側で絞ってよい。
+ */
+
+/**
  * 未解禁の著名人企画を一覧から除外する
  *
  * SPECIAL_VISIBLE が false の間、type = special の企画は
@@ -152,18 +173,21 @@ export async function getEventsList(
   if (!isMicrocmsConfigured) return [];
   try {
     // microCMS filters パラメータの構築
+    // select（date / type）は API では絞れないため、取得後に applyFilters() で適用する
     const filterQueries: string[] = [];
-    if (filters?.date) {
-      filterQueries.push(`date[contains]${filters.date}`);
-    }
-    if (filters?.type) {
-      filterQueries.push(`type[contains]${filters.type}`);
-    }
     if (filters?.building) {
       filterQueries.push(`building[equals]${filters.building}`);
     }
 
     const filterParam = filterQueries.length > 0 ? { filters: filterQueries.join("[and]") } : {};
+
+    /** select の絞り込みを正規化後の値で適用する */
+    const applyFilters = (events: Event[]): Event[] =>
+      events.filter(
+        (event) =>
+          (!filters?.date || event.date === filters.date) &&
+          (!filters?.type || event.type === filters.type)
+      );
 
     // 100件以下なら1回で取得
     if (limit <= MICROCMS_MAX_LIMIT) {
@@ -175,7 +199,7 @@ export async function getEventsList(
           ...filterParam,
         },
       });
-      return excludeUnreleasedSpecial(response.contents.map(normalizeEvent));
+      return excludeUnreleasedSpecial(applyFilters(response.contents.map(normalizeEvent)));
     }
 
     // 100件超: ページネーションで全件取得
@@ -201,7 +225,7 @@ export async function getEventsList(
       offset += perPage;
     }
 
-    return excludeUnreleasedSpecial(allContents.map(normalizeEvent));
+    return excludeUnreleasedSpecial(applyFilters(allContents.map(normalizeEvent)));
   } catch (error) {
     console.error("[getEventsList] Error:", error);
     return [];
@@ -225,10 +249,9 @@ export async function getSpecialEvents(): Promise<Event[]> {
       queries: {
         limit: MICROCMS_MAX_LIMIT,
         orders: "-publishedAt",
-        filters: "type[contains]special",
       },
     });
-    // filters は部分一致のため、正規化後の値で再度絞り込む
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
     return response.contents.map(normalizeEvent).filter((event) => event.type === "special");
   } catch (error) {
     console.error("[getSpecialEvents] Error:", error);

--- a/src/lib/informations.ts
+++ b/src/lib/informations.ts
@@ -48,6 +48,19 @@ function normalizeInformation(rawInfo: RawInformation): Information {
 }
 
 /**
+ * select フィールドは microCMS の filters では絞り込めない
+ *
+ * `[contains]` は select に対して**配列要素の完全一致**で動く。部分一致ではない。
+ * `category` は `sponsor : 協賛企業` のように `値 : ラベル` 形式で登録されているため、
+ * `category[contains]sponsor` は常に 0 件を返す（2026-08-16 に実測。協賛企業一覧が
+ * 空になっていた）。
+ *
+ * ラベルまで含めれば一致するが、入稿側でラベルを直した瞬間に壊れる。
+ * したがって絞り込みは API に任せず、正規化後の値で filter する。
+ * 詳細は `src/lib/events.ts` の同名コメントを参照。
+ */
+
+/**
  * 協賛企業一覧を取得
  * @returns 協賛企業の配列（優先度順）
  */
@@ -58,12 +71,13 @@ export async function getSponsorsList(): Promise<Information[]> {
       endpoint: "informations",
       queries: {
         limit: 100,
-        filters: "category[contains]sponsor",
         orders: "-priority",
       },
     });
-    // データを正規化して返す
-    return response.contents.map(normalizeInformation);
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
+    return response.contents
+      .map(normalizeInformation)
+      .filter((info) => info.category === "sponsor");
   } catch (error) {
     console.error("[getSponsorsList] Error:", error);
     return [];
@@ -80,13 +94,12 @@ export async function getFAQList(): Promise<Information[]> {
     const response: RawInformationListResponse = await client.get({
       endpoint: "informations",
       queries: {
-        limit: 50,
-        filters: "category[contains]faq",
+        limit: 100,
         orders: "-publishedAt",
       },
     });
-    // データを正規化して返す
-    return response.contents.map(normalizeInformation);
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
+    return response.contents.map(normalizeInformation).filter((info) => info.category === "faq");
   } catch (error) {
     console.error("[getFAQList] Error:", error);
     return [];


### PR DESCRIPTION
著名人企画のダミーを公開して実データ確認をしたところ、**公開済みのコンテンツが API から1件も取れない**ことが判明した。原因を追ったところ、`informations` にも同じ問題が及んでいた。

## 原因

**microCMS の `[contains]` は select に対して「配列要素の完全一致」で動く。部分一致ではない。**

本プロジェクトの select は `値 : ラベル` 形式で登録されている（例: `special : スペシャル企画`）。値だけを渡しても一致しない。

実測（2026-08-16）:

| filters | 件数 |
| --- | --- |
| `type[contains]special` | **0** |
| `type[contains]スペシャル` | **0** |
| `type[contains]special : スペシャル企画` | **2** |
| `type[equals]special : スペシャル企画` | 0 |

`informations` でも同様に `category[contains]sponsor` が 0 件、`category[contains]sponsor : 協賛企業` で 1 件。

## 影響

| 関数 | 症状 |
| --- | --- |
| `getSpecialEvents()` | 著名人企画が取れず `/special` が常に準備中（今回の実装のバグ） |
| **`getSponsorsList()`** | **協賛企業一覧が空**（既存バグ） |
| **`getFAQList()`** | **FAQ が空**（既存バグ） |
| `getEventsList()` の `date` / `type` | 呼び出し元が誰も filters を渡していないため潜在。使えば同じ罠 |

> [!WARNING]
> **協賛企業と FAQ は公開フラグに依存しないページです。** コンテンツが入稿された時点で「登録したのに出ない」となるところでした。現在は該当データが1件（協賛のモック）しか無いため顕在化していません。

## 対処

**ラベルに依存しない形にする。** `値 : ラベル` の完全一致で書けば動くが、入稿側でラベルを直した瞬間に壊れる。

そこで **select の絞り込みは API に任せず、正規化後の値で `filter` する**。正規化関数（`normalizeEventType` 等）は既に `split(":")` で先頭を取っているため、ここを唯一の判定点にできる。

`building` は text フィールドで `[equals]` が正しく動くため、API 側に残した。

```diff
- filters: "type[contains]special",
+ // select は API の filters で絞れない。正規化後の値で絞る
+ return response.contents.map(normalizeEvent).filter((event) => event.type === "special");
```

`getFAQList()` の `limit` は 50 → 100 に引き上げた。取得後に絞る方式では、FAQ 以外のコンテンツが取得枠を食うため。

## 実データでの確認

`special-event-test`（公開済み）で検証。**修正前は `/special` が準備中、修正後は実データが表示された。**

| 検証項目 | 結果 |
| --- | --- |
| `/special` に企画が出る | ✅ |
| `/special/special-event-test` が 200 | ✅ |
| 5セクションすべて描画 | ✅ |
| 日程 `both` の展開（10月31日・11月1日） | ✅ |
| 開場「18:00（予定）」がそのまま | ✅ |
| 物販の列（商品名/カラー/サイズ/販売価格/備考）※画像列は消える | ✅ |
| NEW バッジ | ✅ |
| チケット表の行（料金/発売日/販売方法/注意事項/購入）と列（学内生販売/一般販売） | ✅ |
| **購入ボタンの `<a>` が1つだけ**（学内販売は `buttonUrl` 空で消える） | ✅ |
| `rel="noopener noreferrer"` / `target="_blank"` | ✅ |
| **`goodsNote` / `ticketNote` が空 → 補足ブロックが出ない** | ✅ |
| JSON-LD `MusicEvent` + `offers` | ✅ |

- `npx tsc --noEmit` — エラーなし
- `pnpm lint` — エラー 0（警告 13 は既存の `<img>` 由来）

🤖 Generated with [Claude Code](https://claude.com/claude-code)