### PR TITLE
STYLE: 著名人企画LPのフィードバック4件を反映

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,32 @@ body {
       );
     }
   }
+
+  /* SpecialHero: 左下から右上へ抜けるオーバーレイ。
+     ロゴとタイトルを左下へ置くため、最も濃い領域を左下に寄せている。
+
+     2層構造にしている。対角のグラデーションだけでは、テキストが載る下部の帯が
+     右へ行くほど急に薄くなり、白ロゴが入稿されたときに読めなくなるため、
+     下辺に沿った縦のグラデーションを重ねて可読性を担保する。
+
+     page-hero-overlay と同じく、終端は transparent ではなく同色の alpha 0 とし、
+     補間経路を紫に留める（transparent だと灰色を経由して濁る）。 */
+  .special-hero-overlay {
+    background:
+      linear-gradient(
+        to top,
+        oklch(47% 0.165 314deg / 0.72) 0%,
+        oklch(47% 0.165 314deg / 0.3) 28%,
+        oklch(47% 0.165 314deg / 0) 50%
+      ),
+      linear-gradient(
+        to top right,
+        var(--color-primary-600) 0%,
+        oklch(47% 0.165 314deg / 0.62) 35%,
+        oklch(47% 0.165 314deg / 0.28) 60%,
+        oklch(47% 0.165 314deg / 0) 88%
+      );
+  }
 }
 
 @keyframes spin-slow {

--- a/src/components/special/NoticeList.tsx
+++ b/src/components/special/NoticeList.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import type { NoticeSection } from "@/types/events";
 
 interface NoticeListProps {
@@ -27,7 +28,14 @@ export function NoticeList({ notices }: NoticeListProps) {
             key={`${notice.heading}-${index}`}
             className="rounded-xl border border-gray-200 p-4 md:p-5"
           >
-            <h3 className="mb-2 font-bold text-gray-900">{notice.heading}</h3>
+            {/* アイコンは装飾。見出しテキストだけを読み上げさせる */}
+            <h3 className="mb-2 flex items-start gap-2 font-bold text-gray-900">
+              <AlertTriangle
+                className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600"
+                aria-hidden="true"
+              />
+              {notice.heading}
+            </h3>
             {notice.body && (
               <div
                 className="prose prose-sm max-w-none prose-p:text-gray-900/80 prose-a:text-primary"

--- a/src/components/special/SpecialHero.tsx
+++ b/src/components/special/SpecialHero.tsx
@@ -13,15 +13,19 @@ interface SpecialHeroProps {
 /**
  * 著名人企画LPのヒーロー
  *
- * ロゴは透過PNGで入稿される可能性が高いため、必ず暗色の背景を敷いた上に配置します。
- * 白いロゴが白背景に溶けて見えなくなる事故を防ぐためです。
+ * ロゴ・タイトルは左下に置き、オーバーレイも左下が最も濃くなるグラデーションにしています。
+ * ロゴは透過PNGで入稿される可能性が高く、白ロゴが背景に溶ける事故を防ぐためです。
+ * グラデーションの定義は globals.css の `.special-hero-overlay` にあります。
+ *
+ * 配置は PageHero（`flex items-end` + `container mx-auto px-4`）と同じ構造に揃えており、
+ * 白いシート内の本文と左端が一致します。
  *
  * ロゴの有無にかかわらず h1 は出力します（ロゴがある場合は画像の alt が見出しになります）。
  */
 export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps) {
   return (
-    <section className="relative isolate flex min-h-[60vh] items-center justify-center overflow-hidden bg-primary-dark px-4 py-20">
-      {/* 背景写真。ロゴの可読性を確保するため暗くオーバーレイする */}
+    <section className="relative isolate flex min-h-[60vh] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
+      {/* 背景写真 */}
       {photo && (
         <>
           <Image
@@ -33,27 +37,32 @@ export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps)
             className="object-cover"
             aria-hidden="true"
           />
-          <div className="absolute inset-0 bg-primary-dark/70" aria-hidden="true" />
+          <div
+            className="special-hero-overlay pointer-events-none absolute inset-0"
+            aria-hidden="true"
+          />
         </>
       )}
 
-      <div className="relative flex flex-col items-center gap-6 text-center">
-        {logo ? (
-          <h1 className="flex justify-center">
-            <Image
-              src={logo.url}
-              alt={title}
-              width={logo.width ?? 480}
-              height={logo.height ?? 160}
-              priority
-              className="h-auto w-full max-w-[320px] object-contain md:max-w-[480px]"
-            />
-          </h1>
-        ) : (
-          <h1 className="text-3xl font-bold text-white md:text-5xl">{title}</h1>
-        )}
+      <div className="container relative mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex max-w-2xl flex-col gap-4">
+          {logo ? (
+            <h1 className="flex">
+              <Image
+                src={logo.url}
+                alt={title}
+                width={logo.width ?? 480}
+                height={logo.height ?? 160}
+                priority
+                className="h-auto w-full max-w-[320px] object-contain object-left md:max-w-[480px]"
+              />
+            </h1>
+          ) : (
+            <h1 className="text-3xl font-bold text-white md:text-5xl">{title}</h1>
+          )}
 
-        <p className="text-sm text-white/80 md:text-base">{organizer}</p>
+          <p className="text-sm text-white/80 md:text-base">{organizer}</p>
+        </div>
       </div>
     </section>
   );

--- a/src/components/special/SpecialProfile.tsx
+++ b/src/components/special/SpecialProfile.tsx
@@ -35,15 +35,24 @@ export function SpecialProfile({ content, photos }: SpecialProfileProps) {
 
       {hasPhotos && (
         <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {photos?.map((photo) => (
-            <li key={photo.url} className="overflow-hidden rounded-xl border border-gray-200">
+          {/* 同じ画像を複数枚選べるため、URL だけでは key が衝突する */}
+          {photos?.map((photo, index) => (
+            <li
+              key={`${photo.url}-${index}`}
+              className="overflow-hidden rounded-xl border border-gray-200"
+            >
+              {/*
+                縦長の写真が入稿されるとモバイルのスクロール量が跳ね上がるため、
+                高さの上限を 70dvh とし、超過分は中心を基準にクロップする。
+                アスペクト比は object-cover が維持する。
+              */}
               <Image
                 src={photo.url}
                 alt=""
                 width={photo.width ?? 800}
                 height={photo.height ?? 600}
                 sizes="(min-width: 640px) 50vw, 100vw"
-                className="h-auto w-full object-cover"
+                className="max-h-[70dvh] w-full object-cover object-center"
               />
             </li>
           ))}

--- a/src/components/special/TicketTable.tsx
+++ b/src/components/special/TicketTable.tsx
@@ -45,7 +45,7 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
                 <th
                   key={`head-${ticket.name}-${index}`}
                   scope="col"
-                  className="min-w-[200px] px-4 py-3 text-left font-semibold text-gray-900"
+                  className="min-w-[220px] px-4 py-3 text-left font-semibold text-gray-900"
                 >
                   {ticket.name}
                 </th>
@@ -143,7 +143,9 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
                         href={ticket.buttonUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
+                        // ラベルは折り返さない。列に min-w-[220px] を確保してあるため
+                        // 通常の文言なら1行に収まり、超える場合は表の横スクロールで読める
+                        className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
                       >
                         {ticket.buttonLabel || "チケットを購入する"}
                         <svg


### PR DESCRIPTION
実データ（`special-event-test`）での目視レビューで挙がった4件に対応。

> [!NOTE]
> 当初 #76 の上に積んでいたが、#76 のマージ時に base ブランチが削除され PR #77 が自動クローズされたため、`dev` 宛に作り直した。**中身は #77 と同一のコミット（`ec70799`）。**

## 1. 購入ボタンのラベルが3行に折り返していた

`whitespace-nowrap` を付け、列の `min-w` を 200px → **220px** へ。375px 相当で **190×40 の1行**に収まることを実測。

> [!NOTE]
> **「親幅を超えたら折り返す」は CSS 単体では表現できない**（`white-space` は折り返すか否かの二値）。表は `overflow-x: auto` のコンテナに入っているため、想定外に長い文言が入稿された場合は**折り返しではなく横スクロールで読める**形とした。

## 2. 注意事項の見出しに警告アイコンを追加

`lucide-react` の `AlertTriangle` を `text-amber-600` で。年齢制限・不正転売禁止など**読み落とすと当日のトラブルに直結する情報**のため、ブランド色ではなく意味が伝わる色を選んだ。`aria-hidden` を付け、読み上げは見出しテキストのみ。

## 3. 追加写真がモバイルで縦に長すぎた

`max-h-[70dvh]` + `object-cover object-center`。アスペクト比は維持し、超過分は中心を基準にクロップする。720px ビューポート時に **504px（= 70dvh）で上限に張り付く**ことを実測。

## 4. ヒーローを左下グラデーション + 左下配置へ

全面 `bg-primary-dark/70` のベタ塗り・中央配置から、**左下が最も濃いグラデーション**と**左下配置**に変更。配置は `PageHero` と同じ `flex items-end` + `container mx-auto px-4` の構造に揃えたため、白いシート内の本文と左端が一致する。

### オーバーレイを2層にした理由

最初は対角のグラデーション1層で実装したが、**テキストが載る下部の帯が右へ行くほど急に薄くなり**、白ロゴが入稿された場合に読めなくなることが目視で分かった。下辺に沿った縦のグラデーションを重ねて可読性を担保している。

終端を `transparent` ではなく同色の `alpha 0` にするのは `.page-hero-overlay` と同じ理由（**補間経路を紫に留め、灰色を経由させない**）。既存コメントに記されていた知見を踏襲した。

## あわせて修正: key 重複

`SpecialProfile` で `key={photo.url}` を使っていたが、**同じ画像を複数枚選べる**ため衝突し、React が警告を出していた。実データで初めて顕在化した。

## 動作確認

`agent-browser`（viewport 1280×900）で実測。

| 項目 | 結果 |
| --- | --- |
| ヒーロー 1280×432（`min-h-[60vh]`） | ✅ |
| ロゴが左端32px・下端から104px | ✅ |
| オーバーレイ `linear-gradient(to right top, …)` | ✅ |
| 375px 相当で購入ボタンが 190×40 の1行 | ✅ |
| 注意アイコン2個・amber | ✅ |
| 写真が 504px（70dvh）で頭打ち | ✅ |
| 物販表 419px / チケット表 600px > コンテナ 309px で横スクロール | ✅ |
| ページ本体の横溢れなし | ✅ |

- `npx tsc --noEmit` — エラーなし
- `pnpm lint` — エラー 0（警告 13 は既存の `<img>` 由来）

> [!WARNING]
> **検証中に `.next` のキャッシュ不整合を踏んだ。** `globals.css` に追加した `.special-hero-overlay` が生成 CSS に含まれず、HMR でも `.next/cache` 削除でも復旧しなかった。`.next` を丸ごと削除して再起動したところ解決した。**CSS のカスタムクラスを追加したのに効かない場合は、まず `.next` を疑うこと。**

> [!NOTE]
> **Claude in Chrome の hidden タブでは `vh` が 0 と評価され、このページを検証できない。** `min-h-[60vh]` が 0 になりヒーローが潰れ、`fill` の画像も 0×0 になる。「画像が読み込めていない」と誤診しかけた。`agent-browser` では正常に測れる。

Refs #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)