### PR TITLE
RELEASE: select フィルタの修正と著名人企画LPのUI調整

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -153,6 +153,8 @@ docs/
   - **`ssr: false` の描画検証の症状はツールで異なる。** agent-browser は canvas がマウントせず、実 Chrome の `hidden` タブは**マウントするが `300×150` のまま未描画**（要素の存在だけで合格判定すると誤判定する）
   - **外部SPAの管理画面は「操作」に使わない。** 本ワークフローは観測用。設定投入の自動化は失敗が本番に残る（[../dev/microcms.md](./dev/microcms.md) に実例）
   - **`resize_window` は viewport を変えない。** レスポンシブ検証は agent-browser の `--viewport` かコンテナ幅を直接絞る方法で行う（メディアクエリの切り替わりは実機確認）
+  - **Claude in Chrome の `hidden` タブでは `vh` / `svh` / `dvh` が 0 になる。** レイアウトが潰れ「画像が表示されない」と誤診する。`vh` を使うページは agent-browser で検証する
+  - **検証手順そのものが誤ることがある。** Tailwind の任意値を `grep` するときは `-F`（`[...]` が文字クラスになる）。CSS のカスタムクラスが効かないときは `.next` を丸ごと削除する
   - 誤診の実例は [page-transition.md](./frontend/page-transition.md) も参照
 
 - **[layout-patterns.md](./frontend/layout-patterns.md)** - レイアウトパターンと設計原則

--- a/docs/frontend/agent-browser-workflow.md
+++ b/docs/frontend/agent-browser-workflow.md
@@ -126,6 +126,60 @@ c.width === 300 && c.height === 150;
 
 **結論として、`framesIn1s: 0` の環境では `ssr: false` コンポーネントの描画は検証できません。** ラッパー要素の位置・サイズ・z-index・`aria-hidden`、`animate-*` の有無、横スクロールの発生といった**描画に依存しない指標**は検証できるので、そこまでを自動で確認し、回転・チルト・モーション軽減時の静止は実機確認に回してください。
 
+### 例外: Claude in Chrome の `hidden` タブでは `vh` が 0 になる
+
+`visibilityState: "hidden"` のタブでは、**ビューポート由来の単位（`vh` / `svh` / `dvh`）が 0 として評価されます。**
+
+2026-08-16 に `/special/[id]` のヒーローで実測しました。`min-h-[60vh]` のセクションが高さ 0 に潰れ、その中の `next/image` の `fill`（絶対配置で親サイズに追随）も 0×0 になります。
+
+| 計測系                       | `innerHeight` | ヒーロー高さ  | 背景画像 |
+| ---------------------------- | ------------- | ------------- | -------- |
+| Claude in Chrome（`hidden`） | —             | **0**         | **0×0**  |
+| agent-browser 0.13.0         | 720           | 432（= 60vh） | 1280×432 |
+
+**症状が「画像が表示されない」なので、画像の読み込み失敗と誤診します。** 実際には `naturalWidth > 0` で読み込みは成功しており、レイアウトが潰れているだけでした。
+
+判別方法は単純です。
+
+```js
+// 親要素の高さが 0 なら、画像ではなくレイアウトを疑う
+element.getBoundingClientRect().height;
+// 画像自体の読み込みは naturalWidth で見る（レイアウトと独立）
+img.naturalWidth > 0;
+```
+
+**`vh` / `svh` / `dvh` を使うページの検証には agent-browser を使ってください。**
+
+### 検証手順そのものが誤ることがある
+
+観測対象ではなく、**確認の仕方**が結論を狂わせた実例です。
+
+#### `grep` で Tailwind の任意値を検索するときは `-F`
+
+生成CSSに任意値クラスが含まれるかを確認する場面で、`[...]` が正規表現の文字クラスとして解釈され、**存在するのに 0 件と出ました。**
+
+```bash
+# NG: [70dvh] が文字クラスになり一致しない
+grep -c 'max-h-\[70dvh\]' app.css   # → 0（誤り）
+
+# OK: 固定文字列として検索する
+grep -c -F '70dvh' app.css          # → 2（正しい）
+```
+
+「生成されていない」と誤判断し、原因の切り分けを一段遠回りしました。**メタ文字を含むクラス名を数えるときは必ず `-F` を付けてください。**
+
+#### CSS のカスタムクラスが効かないときは `.next` を疑う
+
+`globals.css` に追加した `.special-hero-overlay` が生成CSSに含まれず、**HMR でも `.next/cache` の削除でも復旧しませんでした。** `.next` を丸ごと削除して再起動したところ解決しています。
+
+```bash
+pkill -f "next dev"
+rm -rf .next
+pnpm dev
+```
+
+Tailwind のユーティリティ（`whitespace-nowrap` など既存語彙）は反映されるのに、**新規に定義したカスタムクラスだけが落ちる**という部分的な症状でした。「書いたはずの CSS が効かない」ときは、コードを疑う前にここを潰してください。
+
 ### BFCache の観測
 
 戻る・進むの挙動を検証するとき、BFCache（bfcache）が効いた復帰と、ドキュメントが再作成された復帰は**まったく別の経路**です。取り違えると「防御が効いた」と「そもそも BFCache が起きていない」を区別できません。
@@ -587,6 +641,19 @@ document.documentElement.scrollWidth > document.documentElement.clientWidth; // 
 ```
 
 **限界:** メディアクエリは viewport 基準で評価されるため、この方法では `md:` 以上／未満の切り替わりは再現できない。**ヘッダーのデスクトップ／モバイル切り替えのような検証は実機で行うこと。**
+
+> [!NOTE]
+> **`agent-browser eval` はトップレベル `await` を受け付けない。** 待機を挟む場合は非同期 IIFE で包み、明示的に `return` する。
+>
+> ```bash
+> agent-browser eval "(async () => {
+>   document.querySelector('.target').style.width = '375px';
+>   await new Promise((r) => setTimeout(r, 700));
+>   return JSON.stringify({ w: document.querySelector('.target').clientWidth });
+> })()"
+> ```
+>
+> また **`--viewport` はセッション再利用時に無視される。** 幅を変えるたびに `agent-browser close` を挟むこと。
 
 ## 外部SPAの管理画面は「操作」に使わない
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,32 @@ body {
       );
     }
   }
+
+  /* SpecialHero: 左下から右上へ抜けるオーバーレイ。
+     ロゴとタイトルを左下へ置くため、最も濃い領域を左下に寄せている。
+
+     2層構造にしている。対角のグラデーションだけでは、テキストが載る下部の帯が
+     右へ行くほど急に薄くなり、白ロゴが入稿されたときに読めなくなるため、
+     下辺に沿った縦のグラデーションを重ねて可読性を担保する。
+
+     page-hero-overlay と同じく、終端は transparent ではなく同色の alpha 0 とし、
+     補間経路を紫に留める（transparent だと灰色を経由して濁る）。 */
+  .special-hero-overlay {
+    background:
+      linear-gradient(
+        to top,
+        oklch(47% 0.165 314deg / 0.72) 0%,
+        oklch(47% 0.165 314deg / 0.3) 28%,
+        oklch(47% 0.165 314deg / 0) 50%
+      ),
+      linear-gradient(
+        to top right,
+        var(--color-primary-600) 0%,
+        oklch(47% 0.165 314deg / 0.62) 35%,
+        oklch(47% 0.165 314deg / 0.28) 60%,
+        oklch(47% 0.165 314deg / 0) 88%
+      );
+  }
 }
 
 @keyframes spin-slow {

--- a/src/components/special/NoticeList.tsx
+++ b/src/components/special/NoticeList.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import type { NoticeSection } from "@/types/events";
 
 interface NoticeListProps {
@@ -27,7 +28,14 @@ export function NoticeList({ notices }: NoticeListProps) {
             key={`${notice.heading}-${index}`}
             className="rounded-xl border border-gray-200 p-4 md:p-5"
           >
-            <h3 className="mb-2 font-bold text-gray-900">{notice.heading}</h3>
+            {/* アイコンは装飾。見出しテキストだけを読み上げさせる */}
+            <h3 className="mb-2 flex items-start gap-2 font-bold text-gray-900">
+              <AlertTriangle
+                className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600"
+                aria-hidden="true"
+              />
+              {notice.heading}
+            </h3>
             {notice.body && (
               <div
                 className="prose prose-sm max-w-none prose-p:text-gray-900/80 prose-a:text-primary"

--- a/src/components/special/SpecialHero.tsx
+++ b/src/components/special/SpecialHero.tsx
@@ -13,15 +13,19 @@ interface SpecialHeroProps {
 /**
  * 著名人企画LPのヒーロー
  *
- * ロゴは透過PNGで入稿される可能性が高いため、必ず暗色の背景を敷いた上に配置します。
- * 白いロゴが白背景に溶けて見えなくなる事故を防ぐためです。
+ * ロゴ・タイトルは左下に置き、オーバーレイも左下が最も濃くなるグラデーションにしています。
+ * ロゴは透過PNGで入稿される可能性が高く、白ロゴが背景に溶ける事故を防ぐためです。
+ * グラデーションの定義は globals.css の `.special-hero-overlay` にあります。
+ *
+ * 配置は PageHero（`flex items-end` + `container mx-auto px-4`）と同じ構造に揃えており、
+ * 白いシート内の本文と左端が一致します。
  *
  * ロゴの有無にかかわらず h1 は出力します（ロゴがある場合は画像の alt が見出しになります）。
  */
 export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps) {
   return (
-    <section className="relative isolate flex min-h-[60vh] items-center justify-center overflow-hidden bg-primary-dark px-4 py-20">
-      {/* 背景写真。ロゴの可読性を確保するため暗くオーバーレイする */}
+    <section className="relative isolate flex min-h-[60vh] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
+      {/* 背景写真 */}
       {photo && (
         <>
           <Image
@@ -33,27 +37,32 @@ export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps)
             className="object-cover"
             aria-hidden="true"
           />
-          <div className="absolute inset-0 bg-primary-dark/70" aria-hidden="true" />
+          <div
+            className="special-hero-overlay pointer-events-none absolute inset-0"
+            aria-hidden="true"
+          />
         </>
       )}
 
-      <div className="relative flex flex-col items-center gap-6 text-center">
-        {logo ? (
-          <h1 className="flex justify-center">
-            <Image
-              src={logo.url}
-              alt={title}
-              width={logo.width ?? 480}
-              height={logo.height ?? 160}
-              priority
-              className="h-auto w-full max-w-[320px] object-contain md:max-w-[480px]"
-            />
-          </h1>
-        ) : (
-          <h1 className="text-3xl font-bold text-white md:text-5xl">{title}</h1>
-        )}
+      <div className="container relative mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex max-w-2xl flex-col gap-4">
+          {logo ? (
+            <h1 className="flex">
+              <Image
+                src={logo.url}
+                alt={title}
+                width={logo.width ?? 480}
+                height={logo.height ?? 160}
+                priority
+                className="h-auto w-full max-w-[320px] object-contain object-left md:max-w-[480px]"
+              />
+            </h1>
+          ) : (
+            <h1 className="text-3xl font-bold text-white md:text-5xl">{title}</h1>
+          )}
 
-        <p className="text-sm text-white/80 md:text-base">{organizer}</p>
+          <p className="text-sm text-white/80 md:text-base">{organizer}</p>
+        </div>
       </div>
     </section>
   );

--- a/src/components/special/SpecialProfile.tsx
+++ b/src/components/special/SpecialProfile.tsx
@@ -35,15 +35,24 @@ export function SpecialProfile({ content, photos }: SpecialProfileProps) {
 
       {hasPhotos && (
         <ul className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {photos?.map((photo) => (
-            <li key={photo.url} className="overflow-hidden rounded-xl border border-gray-200">
+          {/* 同じ画像を複数枚選べるため、URL だけでは key が衝突する */}
+          {photos?.map((photo, index) => (
+            <li
+              key={`${photo.url}-${index}`}
+              className="overflow-hidden rounded-xl border border-gray-200"
+            >
+              {/*
+                縦長の写真が入稿されるとモバイルのスクロール量が跳ね上がるため、
+                高さの上限を 70dvh とし、超過分は中心を基準にクロップする。
+                アスペクト比は object-cover が維持する。
+              */}
               <Image
                 src={photo.url}
                 alt=""
                 width={photo.width ?? 800}
                 height={photo.height ?? 600}
                 sizes="(min-width: 640px) 50vw, 100vw"
-                className="h-auto w-full object-cover"
+                className="max-h-[70dvh] w-full object-cover object-center"
               />
             </li>
           ))}

--- a/src/components/special/TicketTable.tsx
+++ b/src/components/special/TicketTable.tsx
@@ -45,7 +45,7 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
                 <th
                   key={`head-${ticket.name}-${index}`}
                   scope="col"
-                  className="min-w-[200px] px-4 py-3 text-left font-semibold text-gray-900"
+                  className="min-w-[220px] px-4 py-3 text-left font-semibold text-gray-900"
                 >
                   {ticket.name}
                 </th>
@@ -143,7 +143,9 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
                         href={ticket.buttonUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
+                        // ラベルは折り返さない。列に min-w-[220px] を確保してあるため
+                        // 通常の文言なら1行に収まり、超える場合は表の横スクロールで読める
+                        className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
                       >
                         {ticket.buttonLabel || "チケットを購入する"}
                         <svg

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -123,6 +123,27 @@ function normalizeEvent(rawEvent: RawEvent): Event {
 const MICROCMS_MAX_LIMIT = 100;
 
 /**
+ * select フィールドは microCMS の filters では絞り込めない
+ *
+ * `[contains]` は select に対して**配列要素の完全一致**で動く。部分一致ではない。
+ * 本プロジェクトの select は `値 : ラベル` 形式（例: `special : スペシャル企画`）で
+ * 登録されているため、値だけを渡すと常に 0 件になる。
+ *
+ * 実測（2026-08-16）:
+ *
+ * | filters                                  | 件数 |
+ * | ---------------------------------------- | ---- |
+ * | `type[contains]special`                  | 0    |
+ * | `type[contains]スペシャル`               | 0    |
+ * | `type[contains]special : スペシャル企画` | 2    |
+ * | `type[equals]special : スペシャル企画`   | 0    |
+ *
+ * ラベルまで含めれば一致するが、**入稿側でラベルを直した瞬間に壊れる**。
+ * したがって select の絞り込みは API に任せず、正規化後の値で filter する。
+ * text フィールド（`building` など）は `[equals]` が正しく動くため API 側で絞ってよい。
+ */
+
+/**
  * 未解禁の著名人企画を一覧から除外する
  *
  * SPECIAL_VISIBLE が false の間、type = special の企画は
@@ -152,18 +173,21 @@ export async function getEventsList(
   if (!isMicrocmsConfigured) return [];
   try {
     // microCMS filters パラメータの構築
+    // select（date / type）は API では絞れないため、取得後に applyFilters() で適用する
     const filterQueries: string[] = [];
-    if (filters?.date) {
-      filterQueries.push(`date[contains]${filters.date}`);
-    }
-    if (filters?.type) {
-      filterQueries.push(`type[contains]${filters.type}`);
-    }
     if (filters?.building) {
       filterQueries.push(`building[equals]${filters.building}`);
     }
 
     const filterParam = filterQueries.length > 0 ? { filters: filterQueries.join("[and]") } : {};
+
+    /** select の絞り込みを正規化後の値で適用する */
+    const applyFilters = (events: Event[]): Event[] =>
+      events.filter(
+        (event) =>
+          (!filters?.date || event.date === filters.date) &&
+          (!filters?.type || event.type === filters.type)
+      );
 
     // 100件以下なら1回で取得
     if (limit <= MICROCMS_MAX_LIMIT) {
@@ -175,7 +199,7 @@ export async function getEventsList(
           ...filterParam,
         },
       });
-      return excludeUnreleasedSpecial(response.contents.map(normalizeEvent));
+      return excludeUnreleasedSpecial(applyFilters(response.contents.map(normalizeEvent)));
     }
 
     // 100件超: ページネーションで全件取得
@@ -201,7 +225,7 @@ export async function getEventsList(
       offset += perPage;
     }
 
-    return excludeUnreleasedSpecial(allContents.map(normalizeEvent));
+    return excludeUnreleasedSpecial(applyFilters(allContents.map(normalizeEvent)));
   } catch (error) {
     console.error("[getEventsList] Error:", error);
     return [];
@@ -225,10 +249,9 @@ export async function getSpecialEvents(): Promise<Event[]> {
       queries: {
         limit: MICROCMS_MAX_LIMIT,
         orders: "-publishedAt",
-        filters: "type[contains]special",
       },
     });
-    // filters は部分一致のため、正規化後の値で再度絞り込む
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
     return response.contents.map(normalizeEvent).filter((event) => event.type === "special");
   } catch (error) {
     console.error("[getSpecialEvents] Error:", error);

--- a/src/lib/informations.ts
+++ b/src/lib/informations.ts
@@ -48,6 +48,19 @@ function normalizeInformation(rawInfo: RawInformation): Information {
 }
 
 /**
+ * select フィールドは microCMS の filters では絞り込めない
+ *
+ * `[contains]` は select に対して**配列要素の完全一致**で動く。部分一致ではない。
+ * `category` は `sponsor : 協賛企業` のように `値 : ラベル` 形式で登録されているため、
+ * `category[contains]sponsor` は常に 0 件を返す（2026-08-16 に実測。協賛企業一覧が
+ * 空になっていた）。
+ *
+ * ラベルまで含めれば一致するが、入稿側でラベルを直した瞬間に壊れる。
+ * したがって絞り込みは API に任せず、正規化後の値で filter する。
+ * 詳細は `src/lib/events.ts` の同名コメントを参照。
+ */
+
+/**
  * 協賛企業一覧を取得
  * @returns 協賛企業の配列（優先度順）
  */
@@ -58,12 +71,13 @@ export async function getSponsorsList(): Promise<Information[]> {
       endpoint: "informations",
       queries: {
         limit: 100,
-        filters: "category[contains]sponsor",
         orders: "-priority",
       },
     });
-    // データを正規化して返す
-    return response.contents.map(normalizeInformation);
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
+    return response.contents
+      .map(normalizeInformation)
+      .filter((info) => info.category === "sponsor");
   } catch (error) {
     console.error("[getSponsorsList] Error:", error);
     return [];
@@ -80,13 +94,12 @@ export async function getFAQList(): Promise<Information[]> {
     const response: RawInformationListResponse = await client.get({
       endpoint: "informations",
       queries: {
-        limit: 50,
-        filters: "category[contains]faq",
+        limit: 100,
         orders: "-publishedAt",
       },
     });
-    // データを正規化して返す
-    return response.contents.map(normalizeInformation);
+    // select は API の filters で絞れない（上記コメント参照）。正規化後の値で絞る
+    return response.contents.map(normalizeInformation).filter((info) => info.category === "faq");
   } catch (error) {
     console.error("[getFAQList] Error:", error);
     return [];


### PR DESCRIPTION
`dev` → `main`。前回リリース（#74）以降の変更。

> [!IMPORTANT]
> **merge しても Production デプロイは作られません。** 本番反映は **`vercel redeploy --target production`** で行ってください。

## 1. select フィルタが常に0件を返していた（#76）

**協賛企業一覧と FAQ が空になる既存バグの修正。** 本リリースで最も影響が大きい。

microCMS の `[contains]` は select に対して**配列要素の完全一致**で動く。本プロジェクトの select は `値 : ラベル` 形式（例: `sponsor : 協賛企業`）のため、値だけを渡すと一致しない。

| filters | 件数 |
| --- | --- |
| `category[contains]sponsor` | **0** |
| `category[contains]sponsor : 協賛企業` | 1 |

影響していた関数は `getSponsorsList()` / `getFAQList()` / `getSpecialEvents()` の3つ。

**ラベルに依存しない形にするため、select の絞り込みは API に任せず正規化後の値で `filter` する方式へ変更した。** 入稿側でラベルを直しても壊れない。

> [!NOTE]
> 協賛企業・FAQ は公開フラグに依存しないページです。**コンテンツが入稿された時点で「登録したのに出ない」となるところでした。** 現在は該当データが1件しか無いため顕在化していません。

## 2. 著名人企画LPのUI調整（#78）

実データでの目視レビューを受けた4件。

- 購入ボタンのラベルが3行に折り返していた → `whitespace-nowrap` + 列幅 220px
- 注意事項の見出しに `AlertTriangle`（amber）を追加
- 追加写真がモバイルで縦に長すぎた → `max-h-[70dvh]` + 中心クロップ
- ヒーローを**左下グラデーション + 左下配置**へ（2層オーバーレイで下部の可読性を担保）

あわせて `SpecialProfile` の key 重複を修正（同じ画像を複数枚選べるため `photo.url` だけでは衝突する）。

## 3. 検証手順の落とし穴を記録（#79）

`docs/frontend/agent-browser-workflow.md` に3件。Claude in Chrome の `hidden` タブで `vh` が 0 になる件、`grep -F` の必要性、`.next` キャッシュ。

## 公開フラグの状態

**本 PR をマージしても、著名人ページは公開されません。**

| フラグ | 現在 | 影響 |
| --- | --- | --- |
| `NEXT_PUBLIC_SPECIAL_VISIBLE` | 未設定（=false） | `/special` は準備中、`/special/[id]` は生成されない |
| `NEXT_PUBLIC_EVENTS_VISIBLE` | 未設定（=false） | `/events` `/timetable` は準備中 |
| `NEXT_PUBLIC_NEWS_VISIBLE` | 未設定（=false） | `/info` は準備中 |

**協賛企業（`/about/sponsors`）と FAQ はフラグに依存しないため、#76 の修正はマージ・本番反映した時点で効きます。**

## 完了判定

```bash
gh api "repos/ManatoYamashita/tcu-setagayafes97-web/deployments?environment=Production&per_page=1" --jq '.[0].sha'
git ls-remote origin refs/heads/main | cut -f1
```

`Aliased:` 表示は DNS を保証しません。`curl -sI` の `server` ヘッダで実応答を確認してください（#69 が未完のため、現時点では `server: nginx` = さくらが返ります）。

## 既知の事象

> [!NOTE]
> #79 の Preview デプロイが **Google Fonts（Noto Sans JP）の取得失敗**（`Error while requesting resource` ×124）で fail しました。同じコミットで GitHub Actions の Build Check は pass しており、**コード起因ではなくビルド時のネットワーク一時障害**と判断しています。本 PR のビルドで解消を確認します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)