### PR TITLE
DOC: 公開フラグの登録先を4箇所に明文化し .env.example の欠落を補完

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ MICROCMS_API_KEY=your-api-key
 NEXT_PUBLIC_EVENTS_VISIBLE=false
 # NEWS: /info 一覧のみ制御（トップのNews・お知らせ詳細・sitemapは常時公開）
 NEXT_PUBLIC_NEWS_VISIBLE=false
+# SPECIAL: 著名人企画（type = special）を全面制御。EVENTS_VISIBLE とは独立したフラグ
+# false のとき /special は準備中表示、/special/[id] は生成されず404。
+# 企画一覧・タイムテーブル・おすすめ企画・sitemap からも type = special を除外する
+# 著名人は解禁日が契約で決まる。microCMS 側を下書きにするだけで済ませず、必ずこのフラグでも塞ぐこと
+NEXT_PUBLIC_SPECIAL_VISIBLE=false
 
 # --------------------------------------------------------------
 # サイトURL（canonical / OGP / sitemap の生成に使用）

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ cp .env.example .env.local
 | `CONTACT_TO_EMAIL`        | お問い合わせ送信先        |  -   |
 | `CONTACT_FROM_EMAIL`      | お問い合わせ送信元        |  -   |
 
+#### コンテンツ公開フラグ
+
+`"true"` のときだけ公開する。未設定・それ以外の値はすべて非公開（安全側デフォルト）。**ビルド時に評価されるため、値を変えたら再ビルド・再デプロイが必要。**
+
+| 変数名                        | 制御対象                                                        |
+| ----------------------------- | --------------------------------------------------------------- |
+| `NEXT_PUBLIC_EVENTS_VISIBLE`  | `/events`・`/timetable`・おすすめ企画・企画詳細・sitemap の企画 |
+| `NEXT_PUBLIC_NEWS_VISIBLE`    | `/info` 一覧                                                    |
+| `NEXT_PUBLIC_SPECIAL_VISIBLE` | 著名人企画（`type = special`）全般。`EVENTS_VISIBLE` とは独立   |
+
+組み合わせ表と注意点は [docs/dev/ci-env.md](./docs/dev/ci-env.md#コンテンツ公開フラグ) を参照。
+
 ### 開発コマンド
 
 | コマンド            | 説明                       |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -112,6 +112,8 @@ docs/
   - **`vercel promote` は使わない。** 再ビルドしないため Preview 環境変数の成果物が本番に出る（`MICROCMS_SERVICE_DOMAIN` は環境別）。`vercel redeploy --target production` を使う
   - **`Aliased:` 表示は DNS を保証しない。** 公開ドメインは `curl -sI` の `server` / `location` ヘッダで実応答を確認する。`NEXT_PUBLIC_URL` のホストが名前解決できるかも確認する
   - **`NEXT_PUBLIC_SPECIAL_VISIBLE` は `EVENTS_VISIBLE` と独立。** 4通りの組み合わせ表あり。著名人ページの先行公開には `getSpecialEvents()` を使う（`getEventsList()` は EVENTS_VISIBLE=false で常に空）
+  - **公開フラグの登録先は4箇所**（`.env.example` / GitHub Variables / Vercel / 本ドキュメント）。**未設定はエラーにならず黙って非公開になるため、登録漏れが「仕様どおりの準備中表示」と区別できない。** 突き合わせコマンドと `SPECIAL_VISIBLE` 登録漏れの実例あり
+  - **`EVENTS_VISIBLE=false` + `SPECIAL_VISIBLE=true` では `/events/[id]` → `/special/[id]` の誘導が効かない。** `getEventById()` が先に `null` を返し、リダイレクト判定へ到達しない
 
 - **[domain-migration.md](./dev/domain-migration.md)** - `setagayafes.org` を第97回の正規ドメインにする手順
   - 第96回（WordPress）は `96th.setagayafes.org` へ退避し、`/96th/*` は 301 で引き継ぐ

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -27,13 +27,18 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 
 ### Repository Variables
 
-| 変数名                        | 内容                     | 値の例                          |
-| ----------------------------- | ------------------------ | ------------------------------- |
-| `NEXT_PUBLIC_URL`             | 本番サイト URL           | `https://setagayafes.tcu.ac.jp` |
-| `NEXT_PUBLIC_GTM_ID`          | Google Tag Manager ID    | `GTM-XXXXXXX`                   |
-| `NEXT_PUBLIC_EVENTS_VISIBLE`  | 企画情報の公開フラグ     | `false`                         |
-| `NEXT_PUBLIC_NEWS_VISIBLE`    | お知らせ情報の公開フラグ | `false`                         |
-| `NEXT_PUBLIC_SPECIAL_VISIBLE` | 著名人企画の公開フラグ   | `false`                         |
+| 変数名                        | 内容                     | 値の例                    | 登録状況（2026-08-17 実測） |
+| ----------------------------- | ------------------------ | ------------------------- | --------------------------- |
+| `NEXT_PUBLIC_URL`             | 本番サイト URL           | `https://setagayafes.org` | **登録済み**                |
+| `NEXT_PUBLIC_GTM_ID`          | Google Tag Manager ID    | `GTM-XXXXXXX`             | 未登録                      |
+| `NEXT_PUBLIC_EVENTS_VISIBLE`  | 企画情報の公開フラグ     | `false`                   | 未登録                      |
+| `NEXT_PUBLIC_NEWS_VISIBLE`    | お知らせ情報の公開フラグ | `false`                   | 未登録                      |
+| `NEXT_PUBLIC_SPECIAL_VISIBLE` | 著名人企画の公開フラグ   | `false`                   | 未登録                      |
+
+> [!NOTE]
+> **この表は「登録すべきもの」であって、現状の登録一覧ではない。** `gh variable list` で確認できるのは `NEXT_PUBLIC_URL` のみ。
+> CI（`feature-ci.yml`）は Lint / Format / Build の検証だけなので、公開フラグが未登録でも **`false` としてビルドが通る**。
+> **つまり CI が緑でも、公開状態のページがビルドできることは何も検証していない。**
 
 ## ワークフローでの参照例
 
@@ -104,6 +109,49 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 > **著名人は解禁日が契約で決まっていることが多く、URL の先行露出が事故になる。**
 > microCMS 側を下書きにするだけで済ませず、必ず `NEXT_PUBLIC_SPECIAL_VISIBLE` でも塞ぐこと。
 
+> [!WARNING]
+> **`EVENTS_VISIBLE=false` / `SPECIAL_VISIBLE=true` の組み合わせでは、`/events/[id]` → `/special/[id]` の誘導が働かない。**
+> `src/app/events/[id]/page.tsx` は `getEventById()` の結果を見てから `type === "special"` を判定するが、
+> `getEventById()` は `EVENTS_VISIBLE=false` の間 microCMS へ問い合わせず `null` を返すため、
+> **リダイレクト判定に到達する前に `notFound()` へ落ちる。**
+> 既に配布済みの `/events/{id}` URL がある場合、この組み合わせの間は誘導されず「企画が見つかりません」になる。
+> 2026-08-17 に本番で実測（`/events/special-event-test` が `/special/...` へ転送されないことを確認）。
+
+### フラグを追加したら登録先は4箇所
+
+> [!IMPORTANT]
+> **公開フラグの未設定はエラーにならず、黙って `false`（非公開）になる。** 安全側デフォルトである代わりに、**登録漏れが「仕様どおりの準備中表示」と見分けられない。** 追加時は下記4箇所すべてを埋めること。
+
+| #   | 登録先                                       | 目的                                     |
+| --- | -------------------------------------------- | ---------------------------------------- |
+| 1   | `.env.example`                               | 新規参加者が `.env.local` を作れるように |
+| 2   | GitHub Repository Variables                  | CI のビルドチェック                      |
+| 3   | Vercel Environment Variables（Prod/Preview） | 実際のデプロイ                           |
+| 4   | 本ファイルの登録一覧・対応表                 | 追跡可能性                               |
+
+#### 実例：`NEXT_PUBLIC_SPECIAL_VISIBLE` の登録漏れ（2026-08-17）
+
+`SPECIAL_VISIBLE` はコードにも本ファイルにも記載済みだったが、**`.env.example` と Vercel の双方から欠落していた。** ローカル `.env.local` にだけ `true` が入っていたため、次の状態になっていた。
+
+| 環境                     | `SPECIAL_VISIBLE` | `/special` の実際の表示  |
+| ------------------------ | ----------------- | ------------------------ |
+| ローカル（`.env.local`） | `true`            | 著名人企画が見える       |
+| Vercel Production        | **未登録＝false** | **準備中 / Coming Soon** |
+
+**「手元で見えている」を本番の状態だと思い込んだのが原因。** 実行委員へ本番URLを共有する直前に発覚した。
+
+登録状況とビルド成果物は必ず実測で確認する。
+
+```bash
+# 3箇所の登録を突き合わせる
+grep -n VISIBLE .env.example
+gh variable list                       # GitHub Repository Variables
+vercel env ls | grep VISIBLE           # environments 列に Production があるか
+
+# ビルド成果物で最終確認（環境変数はビルド時に埋め込まれるため、再デプロイ後に見る）
+curl -s <deployment url>/special | grep -o '準備中'   # 何も出なければ公開されている
+```
+
 ## Vercel の本番反映は手動
 
 > [!IMPORTANT]
@@ -141,11 +189,13 @@ git ls-remote origin refs/heads/main | cut -f1
 
 本プロジェクトは同名の環境変数を環境ごとに別値で登録しています。`vercel env ls` の `environments` 列で確認できます。
 
-| 変数                         | 登録状況                                     |
-| ---------------------------- | -------------------------------------------- |
-| `MICROCMS_SERVICE_DOMAIN`    | **Production と Preview で別行＝別値**       |
-| `MICROCMS_API_KEY`           | Production, Preview で共有／Development は別 |
-| `NEXT_PUBLIC_EVENTS_VISIBLE` | Production, Preview で共有                   |
+| 変数                          | 登録状況                                     |
+| ----------------------------- | -------------------------------------------- |
+| `MICROCMS_SERVICE_DOMAIN`     | **Production と Preview で別行＝別値**       |
+| `MICROCMS_API_KEY`            | Production, Preview で共有／Development は別 |
+| `NEXT_PUBLIC_EVENTS_VISIBLE`  | Production, Preview で共有                   |
+| `NEXT_PUBLIC_NEWS_VISIBLE`    | Production, Preview で共有                   |
+| `NEXT_PUBLIC_SPECIAL_VISIBLE` | Production, Preview で共有                   |
 
 `MICROCMS_SERVICE_DOMAIN` が環境別なので、`promote` すると **Preview の microCMS サービスから取得したコンテンツが本番に出ます。** 正しい操作は Production 環境変数での再ビルドです。
 
@@ -227,4 +277,4 @@ curl -s https://<production deployment url>/robots.txt | grep Sitemap
 
 ---
 
-**最終更新日**: 2026-08-16
+**最終更新日**: 2026-08-17


### PR DESCRIPTION
## 背景

実行委員へ本番URLを共有しようとした際、本番の `/special` が「準備中 / Coming Soon」を返していた。原因は `NEXT_PUBLIC_SPECIAL_VISIBLE` の登録漏れで、ローカル `.env.local` にだけ `true` が入っていた。

**未設定のフラグは例外にならず黙って `false`（非公開）になる。** 安全側デフォルトである代わりに、登録漏れが「仕様どおりの準備中表示」と見分けられない。

## 変更内容

| ファイル | 変更 |
| --- | --- |
| `.env.example` | `NEXT_PUBLIC_SPECIAL_VISIBLE` を追記（3フラグ中これだけ欠落していた） |
| `README.md` | 「コンテンツ公開フラグ」表を追加（3フラグとも未記載だった） |
| `docs/dev/ci-env.md` | Repository Variables 表に実測の登録状況列を追加 / フラグ追加時の登録先4箇所と突き合わせコマンド / `/events` → `/special` 誘導が効かない条件 |
| `docs/INDEX.md` | 上記2点への導線を追加 |

## 実測で判明した事実

いずれも 2026-08-17 に本番・Vercel・GitHub に対して確認した。

1. **GitHub Repository Variables に登録されているのは `NEXT_PUBLIC_URL` のみ。** `ci-env.md` の一覧表は「登録すべきもの」であって現状ではなかったため、注記を追加した。
2. **CI（`feature-ci.yml`）は Lint / Format / Build のみ。** フラグ未登録でも `false` としてビルドが通るため、**CI が緑でも公開状態のページがビルドできることは検証されていない。**
3. **`EVENTS_VISIBLE=false` + `SPECIAL_VISIBLE=true` では `/events/[id]` → `/special/[id]` の誘導が働かない。** `getEventById()` が `EVENTS_VISIBLE=false` の間 `null` を返すため、`type === "special"` の判定へ到達する前に `notFound()` に落ちる。

## 本PRに含めていない別件

- `/events/[id]` の存在しないIDが **HTTP 200**（soft 404）を返す。ルート未一致の `/nonexistent-page-xyz` は正しく 404 のため、`/events/[id]` 固有の挙動。SEO 影響があるため別Issueで扱う。
- Vercel Production の `NEXT_PUBLIC_URL` が `https://setagayafes97.tcu.ac.jp`（**NXDOMAIN**）。GitHub Variables 側は `https://setagayafes.org`。`robots.txt` の `Sitemap:` 行が存在しないホストを指している。`docs/dev/domain-migration.md` の記載とも矛盾するため別途対応が必要。

## 検証

```
pnpm format:check  # All matched files use Prettier code style!
```

ドキュメントと `.env.example` のみの変更。コードへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)