### PR TITLE
STYLE: Aboutページとヘッダーメニューの表示を調整

### DIFF
--- a/src/components/about/ChairpersonSection.tsx
+++ b/src/components/about/ChairpersonSection.tsx
@@ -90,7 +90,7 @@ const TRIANGLE_CLIP = "polygon(50% 0%, 0% 100%, 100% 100%)";
  * DOM 順は縦積み時の読み順（テーマ → 挨拶ヘッダー → 署名 → 本文）に合わせてあり、
  * lg 以上は全要素が col-start / row-start で明示配置されるため DOM 順の影響を受けない。
  *
- * セクションが画面内に入ると各要素が入場する（ScrollTrigger, once）。
+ * 各要素が画面内に入るとそれぞれ入場する（ScrollTrigger, once）。
  * 見出しとテーマ解説は SplitText で行単位に分割してリヴィールする。
  */
 export function ChairpersonSection() {
@@ -115,11 +115,11 @@ export function ChairpersonSection() {
     const splits: SplitText[] = [];
 
     const ctx = gsap.context(() => {
-      const scrollTriggerBase = {
-        trigger: sectionRef.current,
+      const createScrollTrigger = (trigger: Element | null) => ({
+        trigger,
         start: "top 80%",
         once: true,
-      };
+      });
 
       // フェード + スライドアップ（このセクションの基本の入場）
       const fadeUp = (target: Element | null, vars: gsap.TweenVars = {}) => {
@@ -130,7 +130,7 @@ export function ChairpersonSection() {
           duration: 0.7,
           ease: "power4.out",
           force3D: true,
-          scrollTrigger: { ...scrollTriggerBase },
+          scrollTrigger: createScrollTrigger(target),
           ...vars,
         });
       };
@@ -158,7 +158,7 @@ export function ChairpersonSection() {
                 ease: "power3.out",
                 stagger: 0.12,
                 force3D: true,
-                scrollTrigger: { ...scrollTriggerBase },
+                scrollTrigger: createScrollTrigger(headingRef.current),
                 onComplete: () => {
                   headingRevealed = true;
                 },
@@ -188,7 +188,7 @@ export function ChairpersonSection() {
                 ease: "power3.out",
                 stagger: 0.05,
                 force3D: true,
-                scrollTrigger: { ...scrollTriggerBase },
+                scrollTrigger: createScrollTrigger(briefRef.current),
                 onComplete: () => {
                   briefRevealed = true;
                 },
@@ -209,7 +209,7 @@ export function ChairpersonSection() {
           duration: 0.9,
           ease: "power3.out",
           force3D: true,
-          scrollTrigger: { ...scrollTriggerBase },
+          scrollTrigger: createScrollTrigger(imageFrameRef.current),
         });
 
         const imageEl = imageFrameRef.current.querySelector("img");
@@ -219,7 +219,7 @@ export function ChairpersonSection() {
             duration: 1.4,
             ease: "power2.out",
             force3D: true,
-            scrollTrigger: { ...scrollTriggerBase },
+            scrollTrigger: createScrollTrigger(imageFrameRef.current),
           });
         }
       }
@@ -233,7 +233,7 @@ export function ChairpersonSection() {
           ease: "power3.out",
           stagger: 0.12,
           force3D: true,
-          scrollTrigger: { ...scrollTriggerBase },
+          scrollTrigger: createScrollTrigger(messageRef.current),
         });
       }
     }, sectionRef);
@@ -252,7 +252,7 @@ export function ChairpersonSection() {
   return (
     <section
       ref={sectionRef}
-      className="relative overflow-hidden bg-gray-50 py-24 lg:py-32"
+      className="relative overflow-hidden bg-gradient-to-b from-gray-50 via-gray-50 to-secondary py-24 lg:py-32"
       aria-labelledby="about-theme-heading"
     >
       {/* ── 装飾三角形 ×6（lg以上のみ、常時ゆっくり漂う） ── */}

--- a/src/components/layout/NavDropdown.tsx
+++ b/src/components/layout/NavDropdown.tsx
@@ -91,7 +91,7 @@ export function NavDropdown({ item }: NavDropdownProps) {
         onKeyDown={handleKeyDown}
         aria-expanded={isOpen}
         aria-haspopup="true"
-        className="flex items-center gap-1 text-gray-900/80 transition-colors hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2"
+        className="flex items-center gap-1 text-gray-900/80 transition-colors hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600"
       >
         {item.label}
         <ChevronDown
@@ -100,14 +100,14 @@ export function NavDropdown({ item }: NavDropdownProps) {
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 top-full z-60 mt-2 min-w-[200px] rounded-lg border border-gray-200/20 bg-secondary py-2">
+        <div className="absolute left-0 top-full z-60 mt-2 min-w-[200px] rounded-lg border border-gray-200 bg-white py-2">
           {item.children?.map((child) => (
             // key は href ではなく id。href はロケールで変わるため
             <Link
               key={child.id}
               href={child.href}
               hrefLang={child.hrefLang}
-              className="block px-4 py-2 text-sm text-gray-900/80 transition-colors hover:bg-white/10 hover:text-gray-900"
+              className="block px-4 py-2 text-sm text-gray-900/80 transition-colors hover:bg-gray-100 hover:text-gray-900"
               onClick={() => setIsOpen(false)}
             >
               {child.label}


### PR DESCRIPTION
## 概要
- Aboutページの各要素が画面内に入ってからアニメーションするよう調整
- ChairpersonSectionの背景を灰色から紫へつながるグラデーションに変更
- ヘッダー2階層目メニューを白背景に変更
- メニューボタンの白いフォーカス枠を廃止し、キーボード操作時のみ自然なアウトラインを表示

## 検証
- pnpm lint（エラーなし、既存警告13件）
- pnpm format:check
- localhost:3001でブラウザ表示・スクロール発火を確認

## 補足
- 未追跡画像2件はこのPRに含めていません。