### PR TITLE
STYLE: 著名人企画LPのヒーローをヘッダー下の全画面高にし、1組のときは /special から直接LPへ送る

### DIFF
--- a/src/app/special/page.tsx
+++ b/src/app/special/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { getSpecialEvents } from "@/lib/events";
 import { EventCard } from "@/components/events/EventCard";
 import { ComingSoon } from "@/components/common/ComingSoon";
@@ -42,8 +43,9 @@ export const revalidate = 3600;
 /**
  * 著名人企画の一覧ページ
  *
- * 登録が1組でも成立します。URL を手で削って `/special` に到達したときに
- * 行き止まりにしないためのページでもあります。
+ * 著名人が1組だけのときは、一覧に情報がないため、その企画のLPへ送ります。
+ * 2組以上になれば自動的に一覧表示へ戻るため、恒久リダイレクト（308）にはしません。
+ * URL を手で削って `/special` に到達したときに行き止まりにしないためのページでもあります。
  *
  * SPECIAL_VISIBLE が false の間は準備中表示（EVENTS_VISIBLE とは独立）。
  */
@@ -70,6 +72,11 @@ export default async function SpecialPage() {
         />
       </PageSheetLayout>
     );
+  }
+
+  // 1組だけなら一覧を挟まずLPへ送る。ID はハードコードせず取得結果から導く。
+  if (events.length === 1) {
+    redirect(`/special/${events[0].id}`);
   }
 
   return (

--- a/src/components/special/SpecialHero.tsx
+++ b/src/components/special/SpecialHero.tsx
@@ -20,11 +20,21 @@ interface SpecialHeroProps {
  * 配置は PageHero（`flex items-end` + `container mx-auto px-4`）と同じ構造に揃えており、
  * 白いシート内の本文と左端が一致します。
  *
+ * 高さはヘッダーを除いたビューポート全面（`calc(100svh - var(--header-height))`）。
+ * HeroSection・AboutHero と同じ式に揃えています。ヘッダーは `position: sticky` で
+ * 通常フローに場所を取るため、`100svh` をそのまま指定すると下端が画面外へ落ち、
+ * 左下のロゴと開催者名が見切れます（1280x720 で実測: 出演者名が 43px 下にはみ出す）。
+ *
+ * `vh` ではなく `svh` を使うのは、モバイル Safari でアドレスバーの伸縮により
+ * `100vh` が実表示領域を超えるためです。既存2箇所は `h-` ですが、ここだけ `min-h-` に
+ * しているのは、ロゴ画像の高さが入稿次第で変わるため、低いビューポートで
+ * 文字が潰れるより伸びたほうが安全だからです。
+ *
  * ロゴの有無にかかわらず h1 は出力します（ロゴがある場合は画像の alt が見出しになります）。
  */
 export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps) {
   return (
-    <section className="relative isolate flex min-h-[60vh] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
+    <section className="relative isolate flex min-h-[calc(100svh-var(--header-height))] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
       {/* 背景写真 */}
       {photo && (
         <>


### PR DESCRIPTION
## 背景

PR #83（物販セクションの公開フラグ化）は 2026-08-24 14:36 にマージ済みだが、その12分後に本ブランチへ追加した以下2点はマージに間に合わなかった。#83 は既にクローズされているため、新規PRとして切り出す。

## 変更内容

### 1. SpecialHero: `min-h-[60vh]` → `min-h-[calc(100svh-var(--header-height))]`

クライアントフィードバック「著名人企画のHero画像は100svhに拡大」への対応。

素直に `100svh` を指定すると、ヘッダーが `position: sticky` で通常フローに107px場所を取るため下端が画面外へ落ちる。1280x720の実測で出演者名が43pxはみ出すことを確認し、既存の `HeroSection` / `AboutHero` と同じ式に揃えた。

### 2. `/special`: 著名人が1組だけのときは一覧を挟まず直接LPへリダイレクト

IDはハードコードせず `getSpecialEvents()` の結果から導くため、2組以上になれば自動的に一覧表示へ戻る。

## 検証

- `pnpm lint` / `pnpm format:check` / `pnpm build`: すべてpass
- ローカルビルド + agent-browser実測（1280x720）: Hero高さ=ビューポート比1.0、出演者名の下端が可視領域内に収まることを確認
- リダイレクトは動的判定のため、現状（著名人企画が2件登録されているため）は一覧表示のまま。1件になった時点で自動的に発火する

## 依存

- 本PRは #83（マージ済み）の続きのブランチから作成。#83 の内容は既にdevへ含まれているため、本PRの差分はこの2ファイルのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gAfE9hz6g1FQ6jUfsSjwW