### PR TITLE
FIX: 正規ドメイン参照をsetagayafes.orgへ統一

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,8 @@ NEXT_PUBLIC_NEWS_VISIBLE=false
 # --------------------------------------------------------------
 # サイトURL（canonical / OGP / sitemap の生成に使用）
 # --------------------------------------------------------------
-# 未設定時は https://setagayafes.tcu.ac.jp にフォールバック（src/data/site.ts）
-NEXT_PUBLIC_URL=https://setagayafes97.tcu.ac.jp
+# 未設定時は https://setagayafes.org にフォールバック（src/data/site.ts）
+NEXT_PUBLIC_URL=https://setagayafes.org
 
 # --------------------------------------------------------------
 # お問い合わせフォーム（/api/contact・Nodemailer）

--- a/docs/dev/domain-migration.md
+++ b/docs/dev/domain-migration.md
@@ -14,16 +14,27 @@
 ## 現状（未了）
 
 > [!WARNING]
-> **DNS のカットオーバーは未実施。** `setagayafes.org` はさくらを向いており、第96回サイトを配信している。第97回サイトは Vercel のデプロイURLでのみ到達できる。
+> **DNS のカットオーバーは未実施。** `setagayafes.org` はさくらを向いており、第96回サイトを配信している。第97回サイトはVercelのデプロイURLでのみ到達できる。第96回のサブドメインはさくら側に登録済みだが、公開DNSへの反映とSSL発行は未完了。
 
 | 項目                            | 状態                                                         |
 | ------------------------------- | ------------------------------------------------------------ |
 | Vercel のドメイン割当           | **完了**（`setagayafes.org` / `www.setagayafes.org` の両方） |
 | `NEXT_PUBLIC_URL`               | **完了**（Vercel / GitHub Variables とも `setagayafes.org`） |
 | `/96th/*` の 301                | **実装済み**（`next.config.ts`）                             |
-| `96th.setagayafes.org` の作成   | **未了**（さくら側の作業）                                   |
+| `96th.setagayafes.org` の作成   | **完了**（さくら側、2026-08-24）                             |
+| 第96回ファイルバックアップ      | **完了**（SnapUP、2026-08-24、正常終了）                     |
+| 第96回DBバックアップ            | **未了**（phpMyAdmin認証情報待ち）                           |
+| 第96回サブドメインのSSL         | **未了**（DNS名前解決の反映待ち）                            |
 | WordPress の `siteurl` / `home` | **未了**（さくら側の作業）                                   |
 | `setagayafes.org` の DNS 切替   | **未了**（さくら側の作業）                                   |
+
+### 2026-08-24 の実施内容
+
+- さくらに `96th.setagayafes.org` を追加し、公開フォルダーを `~/www/top/96th` に設定。
+- SnapUPで `/home/setagayafes/www/top/96th` のファイルバックアップを取得（スナップショット #1、正常終了）。
+- 旧ドメイン参照を `https://setagayafes.org` に統一し、`sitemap.xml` / `robots.txt` は `siteConfig.metadata.siteUrl` から生成するよう修正。
+- `next.config.ts` の `setagayafes.org/96th/*` → `96th.setagayafes.org/*` の301設定が `main` に存在することを確認。
+- DNS名前解決前のため、Let's EncryptのSSL発行は保留。
 
 ## なぜ rewrite ではなく redirect なのか
 
@@ -141,4 +152,4 @@ curl -s https://setagayafes.org/robots.txt | grep Sitemap
 
 ---
 
-**最終更新日**: 2026-08-15
+**最終更新日**: 2026-08-24

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -47,19 +47,19 @@
 
 ## ページ構成
 
-- [トップページ](https://setagayafes.tcu.ac.jp/): メインビジュアル、開催概要、最新ニュース、おすすめ企画
-- [企画を探す](https://setagayafes.tcu.ac.jp/events): 企画検索・一覧（日程・場所・カテゴリ・キーワードで絞り込み）
-- [タイムテーブル](https://setagayafes.tcu.ac.jp/timetable): ステージイベントの時間割
-- [マップ](https://setagayafes.tcu.ac.jp/map): キャンパスマップ
-- [アクセス](https://setagayafes.tcu.ac.jp/map/access): 交通アクセス情報
-- [お知らせ](https://setagayafes.tcu.ac.jp/info): ニュース・お知らせ一覧
-- [ご来場の方へ](https://setagayafes.tcu.ac.jp/info/guide): 来場時の注意事項・ルール
-- [よくある質問](https://setagayafes.tcu.ac.jp/info/faq): FAQ
-- [パンフレット](https://setagayafes.tcu.ac.jp/info/pamphlet): パンフレットダウンロード
-- [委員会について](https://setagayafes.tcu.ac.jp/about): 委員長挨拶・理念
-- [協賛企業](https://setagayafes.tcu.ac.jp/about/sponsors): 協賛企業一覧
-- [お問い合わせ](https://setagayafes.tcu.ac.jp/about/contact): お問い合わせフォーム
-- [プライバシーポリシー](https://setagayafes.tcu.ac.jp/about/privacy): 個人情報の取り扱い
+- [トップページ](https://setagayafes.org/): メインビジュアル、開催概要、最新ニュース、おすすめ企画
+- [企画を探す](https://setagayafes.org/events): 企画検索・一覧（日程・場所・カテゴリ・キーワードで絞り込み）
+- [タイムテーブル](https://setagayafes.org/timetable): ステージイベントの時間割
+- [マップ](https://setagayafes.org/map): キャンパスマップ
+- [アクセス](https://setagayafes.org/map/access): 交通アクセス情報
+- [お知らせ](https://setagayafes.org/info): ニュース・お知らせ一覧
+- [ご来場の方へ](https://setagayafes.org/info/guide): 来場時の注意事項・ルール
+- [よくある質問](https://setagayafes.org/info/faq): FAQ
+- [パンフレット](https://setagayafes.org/info/pamphlet): パンフレットダウンロード
+- [委員会について](https://setagayafes.org/about): 委員長挨拶・理念
+- [協賛企業](https://setagayafes.org/about/sponsors): 協賛企業一覧
+- [お問い合わせ](https://setagayafes.org/about/contact): お問い合わせフォーム
+- [プライバシーポリシー](https://setagayafes.org/about/privacy): 個人情報の取り扱い
 
 ## お問い合わせ
 
@@ -74,5 +74,5 @@
 
 ## 公式Webサイト
 
-- URL: https://setagayafes.tcu.ac.jp
+- URL: https://setagayafes.org
 - 過去の世田谷祭: https://setagayafes.org/

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,12 @@
 import { MetadataRoute } from "next";
+import { siteConfig } from "@/data/site";
 
 /**
  * robots.txt自動生成
  * Next.js 14+ の robots.ts ファイルで動的生成
  */
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = "https://setagayafes97.tcu.ac.jp"; // 本番URLに変更
+  const baseUrl = siteConfig.metadata.siteUrl;
 
   return {
     rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,14 @@
 import { MetadataRoute } from "next";
 import { getEventsList, getSpecialEvents } from "@/lib/events";
 import { getNewsList } from "@/lib/news";
+import { siteConfig } from "@/data/site";
 
 /**
  * サイトマップ自動生成
  * Next.js 14+ の sitemap.ts ファイルで動的生成
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = "https://setagayafes97.tcu.ac.jp"; // 本番URLに変更
+  const baseUrl = siteConfig.metadata.siteUrl;
 
   // 静的ページ
   const staticPages: MetadataRoute.Sitemap = [

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -41,7 +41,7 @@ export const siteConfig = {
   // メタデータ
   metadata: {
     siteName: "東京都市大学 第97回 世田谷祭",
-    siteUrl: process.env.NEXT_PUBLIC_URL || "https://setagayafes.tcu.ac.jp",
+    siteUrl: process.env.NEXT_PUBLIC_URL || "https://setagayafes.org",
     ogImage: "/ogp.webp",
   },
 


### PR DESCRIPTION
## 概要
- sitemap.xml / robots.txt のベースURLを siteConfig.metadata.siteUrl に統一
- NEXT_PUBLIC_URL と未設定時のフォールバックを setagayafes.org に更新
- llms.txt の旧ドメイン参照を更新
- 第96回アーカイブ301設定が main に存在することを確認

## 検証
- pnpm lint（エラーなし、既存警告13件）
- pnpm format:check
- NEXT_PUBLIC_URL=https://setagayafes.org pnpm build（終了コード0）
- ローカルProductionサーバーで /96th/access?q=1 の301を確認
- robots.txt / sitemap.xml が setagayafes.org を出力することを確認
- 旧ドメイン参照検索 0件

DNS切替は別作業として、WordPressのDBバックアップ・siteurl/home変更・96th DNS/SSL確認後に実施します。