### PR TITLE
著名人企画詳細のISRを10分に短縮

### DIFF
--- a/src/app/special/[id]/page.tsx
+++ b/src/app/special/[id]/page.tsx
@@ -16,9 +16,9 @@ interface SpecialPageProps {
 }
 
 /**
- * ISR設定: 1時間ごとに再検証
+ * ISR設定: 開発中は変更反映を早めるため10分ごとに再検証
  */
-export const revalidate = 3600;
+export const revalidate = 600;
 
 /**
  * 静的パラメータ生成


### PR DESCRIPTION
## 概要

開発中のmicroCMSコンテンツ変更を早く確認できるよう、著名人企画詳細ページのISR再検証間隔を短縮します。

- `/special/[id]` の `revalidate` を3600秒から600秒へ変更
- 開発中の暫定設定であることをコードコメントへ明記
- `/special` 一覧や他ページの再検証間隔は変更なし

## 検証

- `pnpm exec prettier --check 'src/app/special/[id]/page.tsx'`
- `pnpm exec tsc --noEmit`
- `pnpm lint`（エラー0、既存警告13件）
- `pnpm build`

## 反映時の注意

`revalidate` はビルド成果物へ反映されるため、マージ後にProductionの再ビルド・デプロイが必要です。
