### PR TITLE
perf: split and remove unused font CSS

### DIFF
--- a/docs/frontend/design.md
+++ b/docs/frontend/design.md
@@ -178,10 +178,11 @@ Kaisei Opti は毛筆書体（楷書）の筆法を残しつつ、現代的な�
 
 ```tsx
 // src/app/layout.tsx
+// src/components/layout/KaiseiFont.ts
 import { Kaisei_Opti } from "next/font/google";
 
 const kaiseiOpti = Kaisei_Opti({
-  weight: ["400", "500", "700"],
+  weight: ["400", "700"],
   subsets: ["latin"],
   display: "swap",
   variable: "--font-kaisei-opti",
@@ -189,7 +190,8 @@ const kaiseiOpti = Kaisei_Opti({
 ```
 
 `next/font` の変数をルートへ付けるとフォントCSSが全ページへ配信される。
-使用箇所のないフォントは将来用に読み込まず、必要になった時点で追加する。
+使用箇所のないフォントは将来用に読み込まず、必要になった時点で追加する。Kaisei Opti は
+ページ見出しでのみ遅延ロードし、本文はOSのシステムフォントを使用する。
 性能上の判断基準は [performance.md](./performance.md) を参照する。
 
 ```css
@@ -286,7 +288,7 @@ Aboutページの開催概要は、カード状の枠や行ごとの区切りを
 
   /* ===== Typography ===== */
   --font-display: var(--font-kaisei-opti), "Hiragino Mincho Pro", "Yu Mincho", serif;
-  --font-body: "Noto Sans JP", "Hiragino Sans", sans-serif;
+  --font-body: ui-sans-serif, system-ui, sans-serif, "Hiragino Sans", sans-serif;
 
   --text-xs: 0.75rem; /* 12px */
   --text-sm: 0.875rem; /* 14px */

--- a/docs/frontend/performance.md
+++ b/docs/frontend/performance.md
@@ -158,6 +158,24 @@ PageSpeed Insightsを再計測し、未使用CSS、render-blocking、強制リ�
 4. Lighthouse を同条件で複数回実行し、中央値を比較する。
 5. 本番反映後は PageSpeed Insights で LCP 内訳、画像削減量、アクセシビリティ監査を再確認する。
 
+## 2026-08-26 フォントCSSの分割・削減
+
+PR #106 の本番 mobile 計測では、初期HTMLのCSSリンクは3本に減った一方、遅延後に読み込まれる
+フォントCSSが未使用CSSとして約97 KiB残った。ブラウザ実測で `font-sans` はシステムフォントへ
+解決しており、Noto Sans JP の `@font-face`（転送約31 KiB）は使用されていなかった。
+
+本PRでは次を行う。
+
+- 未使用だった Noto Sans JP の `next/font` import と変数を削除し、`font-sans` を明示的なシステム
+  フォントスタックへ戻す。
+- Dela Gothic One はホームの `HeroSection` だけで遅延ロードし、他ページへCSSを配信しない。
+- Kaisei Opti はホームの初期ビューポートでは読み込まず、非ホームではハイドレーション後、ホームでは
+  ABOUT / NEWS がビューポートへ近づいた時点で一度だけ読み込む。
+
+これによりホーム初期表示からNoto Sans JPとKaisei OptiのフォントCSSを外し、ブランド見出しは
+対象ページ・対象セクションで適用する。初期の見た目をシステムフォントで崩さないこと、ABOUT / NEWS
+のスクロール演出とフォント適用が競合しないことをブラウザで確認する。
+
 ## 関連
 
 - GitHub Issue #101

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,7 +37,9 @@
   --color-primary-dark: var(--color-primary-600);
 
   /* フォント設定 */
-  --font-sans: var(--font-noto-sans-jp), sans-serif;
+  --font-sans:
+    ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --font-serif: var(--font-kaisei-opti), serif;
   --font-heading: var(--font-kaisei-opti), serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import { siteConfig } from "@/data/site";
 import { Header } from "@/components/layout/Header";
@@ -7,17 +6,7 @@ import { HtmlLangSync } from "@/components/layout/HtmlLangSync";
 import { Footer } from "@/components/layout/Footer";
 import { Opener } from "@/components/layout/Opener";
 import { AgentationDevTool } from "@/components/dev/AgentationDevTool";
-import { DeferredDecorativeFontsLoader } from "@/components/layout/DeferredDecorativeFontsLoader";
-
-const notoSansJP = Noto_Sans_JP({
-  subsets: ["latin"],
-  weight: "variable",
-  variable: "--font-noto-sans-jp",
-  display: "swap",
-  // 日本語フォントは unicode-range ごとに多数のファイルへ分割される。
-  // 全分割ファイルを preload せず、実際に使う文字だけブラウザに選ばせる。
-  preload: false,
-});
+import { DeferredKaiseiFontsLoader } from "@/components/layout/DeferredKaiseiFontsLoader";
 
 export const metadata: Metadata = {
   title: {
@@ -64,9 +53,9 @@ export default function RootLayout({
   return (
     // 初期値は既定ロケール。実際のロケールへは HtmlLangSync が同期する
     <html lang="ja">
-      <body className={`${notoSansJP.variable} font-sans antialiased text-gray-900`}>
+      <body className="font-sans antialiased text-gray-900">
         <HtmlLangSync />
-        <DeferredDecorativeFontsLoader />
+        <DeferredKaiseiFontsLoader />
         <Opener />
         <Header />
         {children}

--- a/src/components/about/AboutHero.tsx
+++ b/src/components/about/AboutHero.tsx
@@ -173,11 +173,7 @@ export function AboutHero() {
         >
           {description}
         </p>
-        <h1
-          ref={titleRef}
-          className="leading-tight"
-          style={{ fontFamily: "var(--font-noto-sans-jp), sans-serif" }}
-        >
+        <h1 ref={titleRef} className="leading-tight" style={{ fontFamily: "var(--font-sans)" }}>
           <span className="block text-2xl font-semibold tracking-[0.08em] text-gray-900 sm:text-3xl lg:text-4xl">
             第
             <span

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { gsap } from "gsap";
 
 import { aboutConfig } from "@/data/about";
+import { loadKaiseiFont } from "@/components/layout/loadKaiseiFont";
 
 const { topSection } = aboutConfig;
 
@@ -36,6 +37,7 @@ export function AboutSection() {
     const startAnimation = async () => {
       // ABOUT is below the hero on the initial view. Load ScrollTrigger only
       // when the section is close to entering the viewport.
+      void loadKaiseiFont();
       const { ScrollTrigger } = await import("gsap/ScrollTrigger");
       if (disposed || ctxRef.current) return;
       gsap.registerPlugin(ScrollTrigger);

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -7,6 +7,7 @@ import { gsap } from "gsap";
 import { siteConfig } from "@/data/site";
 import { cn } from "@/lib/utils";
 import type { News, NewsType } from "@/types/news";
+import { DeferredDecorativeFontsLoader } from "@/components/layout/DeferredDecorativeFontsLoader";
 
 /**
  * 日付文字列(YYYY-MM-DD)から年・月・日・曜日を分解
@@ -160,6 +161,7 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
       id="hero-section"
       className="w-full h-[calc(100svh-var(--header-height))] relative z-10 overflow-hidden flex items-center justify-center pb-16 md:pb-20 lg:pb-24"
     >
+      <DeferredDecorativeFontsLoader />
       {/* [z-20] ロゴ画像（中央配置） */}
       <div className="relative z-20 flex w-full max-w-[75vw] -translate-y-10 items-center justify-center sm:max-w-[50vw] sm:-translate-y-6 md:max-w-[35vw] md:translate-y-0 lg:max-w-[30vw]">
         <Image

--- a/src/components/home/NewsSectionInteractive.tsx
+++ b/src/components/home/NewsSectionInteractive.tsx
@@ -7,6 +7,7 @@ import { gsap } from "gsap";
 import type { News } from "@/types/news";
 import { CircularText } from "@/components/ui/CircularText";
 import { NewsFilter } from "./NewsFilter";
+import { loadKaiseiFont } from "@/components/layout/loadKaiseiFont";
 
 interface NewsSectionProps {
   newsList: News[];
@@ -37,6 +38,7 @@ export function NewsSectionInteractive({ newsList }: NewsSectionProps) {
     const startAnimation = async () => {
       // NEWS is below the initial viewport. Defer the ScrollTrigger bundle and
       // its layout reads until the section is close to entering the viewport.
+      void loadKaiseiFont();
       const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
       if (prefersReduced) {

--- a/src/components/layout/DeferredDecorativeFonts.tsx
+++ b/src/components/layout/DeferredDecorativeFonts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { Dela_Gothic_One, Kaisei_Opti } from "next/font/google";
+import { Dela_Gothic_One } from "next/font/google";
 
 const delaGothicOne = Dela_Gothic_One({
   subsets: ["latin"],
@@ -11,19 +11,11 @@ const delaGothicOne = Dela_Gothic_One({
   preload: false,
 });
 
-const kaiseiOpti = Kaisei_Opti({
-  subsets: ["latin"],
-  weight: ["400", "700"],
-  variable: "--font-kaisei-opti",
-  display: "swap",
-  preload: false,
-});
-
 export function DeferredDecorativeFonts() {
   useEffect(() => {
     const body = document.body;
-    body.classList.add(delaGothicOne.variable, kaiseiOpti.variable);
-    return () => body.classList.remove(delaGothicOne.variable, kaiseiOpti.variable);
+    body.classList.add(delaGothicOne.variable);
+    return () => body.classList.remove(delaGothicOne.variable);
   }, []);
 
   return null;

--- a/src/components/layout/DeferredKaiseiFontsLoader.tsx
+++ b/src/components/layout/DeferredKaiseiFontsLoader.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { loadKaiseiFont } from "./loadKaiseiFont";
+
+/** Load the heading font on every route except the home initial viewport. */
+export function DeferredKaiseiFontsLoader() {
+  useEffect(() => {
+    if (window.location.pathname === "/") return;
+    void loadKaiseiFont();
+  }, []);
+
+  return null;
+}

--- a/src/components/layout/KaiseiFont.ts
+++ b/src/components/layout/KaiseiFont.ts
@@ -1,0 +1,9 @@
+import { Kaisei_Opti } from "next/font/google";
+
+export const kaiseiOpti = Kaisei_Opti({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-kaisei-opti",
+  display: "swap",
+  preload: false,
+});

--- a/src/components/layout/loadKaiseiFont.ts
+++ b/src/components/layout/loadKaiseiFont.ts
@@ -1,0 +1,15 @@
+let kaiseiFontPromise: Promise<void> | undefined;
+
+/**
+ * Kaisei Opti is needed by page headings, but not by the home hero's initial viewport.
+ * Keep its next/font CSS in a separate chunk and load it once on demand.
+ */
+export function loadKaiseiFont(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+
+  kaiseiFontPromise ??= import("./KaiseiFont").then(({ kaiseiOpti }) => {
+    document.body.classList.add(kaiseiOpti.variable);
+  });
+
+  return kaiseiFontPromise;
+}


### PR DESCRIPTION
## 概要
- 実測で未使用だった Noto Sans JP の next/font CSS と変数を削除
- Dela Gothic One をホームの HeroSection 専用の遅延チャンクへ限定
- Kaisei Opti を非ホームのハイドレーション後、ホームの ABOUT/NEWS 接近時に一度だけ遅延ロード

## 効果
- ローカル本番ビルドのホーム初期HTMLは共通CSS 2本のみ（フォントCSSなし）
- Noto Sans JP の約31 KiB転送分を削減し、Kaisei/Dela は必要な画面・タイミングに限定
- `/about` の見出しフォント適用とホームのスクロール演出を維持

## 検証
- `pnpm format:check`
- `pnpm lint`（既存warning 7件、error 0件）
- `pnpm exec tsc --noEmit`
- `pnpm build`
- ローカル本番サーバーを390x844で確認：ホーム初期CSSは共通2本、スクロール後にKaiseiを追加、`/about` はハイドレーション後にKaisei適用、ブラウザエラーなし

本PRでは本番PageSpeed Insightsの再計測はマージ・デプロイ後に実施します。