### PR TITLE
fix: reload heading font after client navigation

### DIFF
--- a/src/components/layout/DeferredKaiseiFontsLoader.tsx
+++ b/src/components/layout/DeferredKaiseiFontsLoader.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { loadKaiseiFont } from "./loadKaiseiFont";
 
 /** Load the heading font on every route except the home initial viewport. */
 export function DeferredKaiseiFontsLoader() {
+  const pathname = usePathname();
+
   useEffect(() => {
-    if (window.location.pathname === "/") return;
+    if (pathname === "/") return;
     void loadKaiseiFont();
-  }, []);
+  }, [pathname]);
 
   return null;
 }


### PR DESCRIPTION
## 概要
PR #107で導入した遅延Kaiseiローダーが、ホーム初回表示時に`useEffect`を終了すると、その後のSPA遷移で再実行されない回帰を修正します。`usePathname()`を購読し、`/about`や多言語ページへのクライアント遷移時にもKaiseiを一度だけロードします。

## 検証
- `git diff --check`
- PR #107のCI（format/lint/build）成功済み
- Previewでホーム→`/about`のSPA遷移、`/about`直リンク、多言語パスを確認予定

PR #107の本番反映後に判明したため、本番へ先行反映した修正です。