### PR TITLE
SEO: 第97回の公式サイトシグナルを強化

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -133,7 +133,8 @@ docs/
 - **[seo-metadata.md](./dev/seo-metadata.md)** - 共通metadata・canonicalとテストページ除外
   - ページごとのmetadata、canonical、Open Graph、Twitter Cardの生成方針
   - 多言語ページのcanonicalとhreflang相当のalternate設定
-  - 年次切替後のfavicon・構造化データ・画像サイトマップとSearch Console再送信の運用
+  - 年次切替後のfavicon・サイト主体/開催イベント構造化データ・画像サイトマップとSearch Console再送信の運用
+  - 第96回アーカイブをクロール可能なままnoindex化し、検索結果から恒久除外する運用
   - `/api-test` と `/test-ui` を本番404にする運用
 
 - **[microcms.md](./dev/microcms.md)** - microCMS API 制約と実装パターン

--- a/docs/dev/seo-metadata.md
+++ b/docs/dev/seo-metadata.md
@@ -8,6 +8,7 @@
 - 多言語ページは各ロケールURLを canonical とし、`alternates.languages` に `ja`、`en`、`zh`、`ko`、`x-default` を出力する。
 - ページ固有のOG画像がない場合は `/ogp.webp`（1200×630）を使用する。microCMS画像を使用する場合は絶対URLへ変換する。
 - トップページは `WebSite` のJSON-LDで第97回の名称・説明・正規URLを明示する。
+- トップページのJSON-LDは `WebSite`、主催 `Organization`、祭全体の `Event` を `@graph` で接続する。サイト名は年次をまたいで一貫する簡潔な「世田谷祭」、第97回の正式名称は `alternateName` とページタイトルで示す。
 - faviconはクロール可能な500×500 PNG（`/images/brand/favicon.png`）を安定URLで配信する。
 - Googlebotには大きな画像プレビューを許可し、サイトマップの主要ページに代表画像を含める。ただし検索結果画像の採用はGoogle側の判断であり保証されない。
 
@@ -20,6 +21,13 @@
 5. 反映まで数日以上かかる場合があるため、検索結果を継続観測する。
 
 `og:image` はSNS共有向けの指定であり、Google検索結果のサムネイルを直接固定するものではない。
+
+## 第96回アーカイブの検索除外
+
+- `96th.setagayafes.org` は閲覧用アーカイブとして残すが、全HTMLと画像などの非HTMLリソースへ `X-Robots-Tag: noindex` を付与する。
+- `robots.txt` で `/` をクロール禁止にしない。Googlebotが既存URLを再クロールして `noindex` を確認できないと、検索結果からの恒久的な削除が遅れるため。
+- Search Consoleの削除ツールは一時的な非表示を早める補助手段として使い、恒久対応はサーバー側の `noindex` とする。
+- 第96回のサイトマップはSearch Consoleから削除し、新規送信しない。第97回の `https://setagayafes.org/sitemap.xml` のみ再送信する。
 
 ## テストページ
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { AgentationDevTool } from "@/components/dev/AgentationDevTool";
 import { DeferredKaiseiFontsLoader } from "@/components/layout/DeferredKaiseiFontsLoader";
 
 export const metadata: Metadata = {
+  applicationName: siteConfig.metadata.searchSiteName,
   title: {
     default: siteConfig.metadata.siteName,
     template: `%s | ${siteConfig.shortName}`,
@@ -18,7 +19,7 @@ export const metadata: Metadata = {
     title: siteConfig.metadata.siteName,
     description: siteConfig.description,
     url: siteConfig.metadata.siteUrl,
-    siteName: siteConfig.metadata.siteName,
+    siteName: siteConfig.metadata.searchSiteName,
     images: [
       {
         url: siteConfig.metadata.ogImage,
@@ -37,6 +38,8 @@ export const metadata: Metadata = {
     images: [siteConfig.metadata.ogImage],
   },
   metadataBase: new URL(siteConfig.metadata.siteUrl),
+  creator: siteConfig.organization.name,
+  publisher: siteConfig.organization.name,
   alternates: {
     canonical: "/",
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,18 +5,9 @@ import { FeaturedEvents } from "@/components/home/FeaturedEvents";
 import { SponsorBanner } from "@/components/home/SponsorBanner";
 import { getLatestHeroNews, getNewsList } from "@/lib/news";
 import { NEWS_VISIBLE, siteConfig } from "@/data/site";
+import { createHomeStructuredData, serializeJsonLd } from "@/lib/structured-data";
 
-const homeUrl = new URL("/", siteConfig.metadata.siteUrl).toString();
-const websiteStructuredData = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "@id": `${homeUrl}#website`,
-  url: homeUrl,
-  name: siteConfig.metadata.siteName,
-  alternateName: [`第${siteConfig.edition}回 世田谷祭`, siteConfig.shortName],
-  description: siteConfig.description,
-  inLanguage: "ja",
-};
+const homeStructuredData = createHomeStructuredData();
 
 /**
  * トップページ
@@ -32,7 +23,7 @@ export default async function Home() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(websiteStructuredData).replace(/</g, "\\u003c"),
+          __html: serializeJsonLd(homeStructuredData),
         }}
       />
       <div className="hero-about-bg">

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -33,14 +33,21 @@ export const siteConfig = {
 
   // SNS
   sns: {
-    twitter: "https://x.com/setagayafes_tcu?s=11",
-    instagram: "https://www.instagram.com/setagayafes_sfa?igsh=bWpzYWpqOGozZ3Nr&utm_source=qr",
-    youtube: "https://youtube.com/@setagayafes?si=WvB8ya5RrqvHg0Vj",
+    twitter: "https://x.com/setagayafes_tcu",
+    instagram: "https://www.instagram.com/setagayafes_sfa/",
+    youtube: "https://www.youtube.com/@setagayafes",
+  },
+
+  // 主催組織（構造化データと発行者情報で共通利用）
+  organization: {
+    name: "東京都市大学 世田谷祭実行委員会",
+    currentName: "第97回東京都市大学世田谷祭実行委員会",
   },
 
   // メタデータ
   metadata: {
     siteName: "東京都市大学 第97回 世田谷祭",
+    searchSiteName: "世田谷祭",
     siteUrl: process.env.NEXT_PUBLIC_URL || "https://setagayafes.org",
     ogImage: "/ogp.webp",
   },

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -98,7 +98,7 @@ export function createPageMetadata({
       title: fullTitle,
       description,
       url: canonicalUrl,
-      siteName,
+      siteName: siteConfig.metadata.searchSiteName,
       images,
       locale: localeOpenGraph[locale],
       type,

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -1,0 +1,93 @@
+import { siteConfig } from "@/data/site";
+
+export const siteUrl = new URL("/", siteConfig.metadata.siteUrl).toString();
+export const organizationId = `${siteUrl}#organization`;
+export const websiteId = `${siteUrl}#website`;
+export const festivalId = `${siteUrl}#festival`;
+
+export function absoluteSiteUrl(pathname: string): string {
+  return new URL(pathname, siteUrl).toString();
+}
+
+/**
+ * JSON-LDをscript要素へ安全に埋め込む。
+ * CMS由来の文字列に`</script>`相当が含まれても要素を閉じないよう`<`をescapeする。
+ */
+export function serializeJsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
+export function createHomeStructuredData() {
+  const logoUrl = absoluteSiteUrl("/images/brand/favicon.png");
+  const ogImageUrl = absoluteSiteUrl(siteConfig.metadata.ogImage);
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": websiteId,
+        url: siteUrl,
+        name: siteConfig.metadata.searchSiteName,
+        alternateName: [
+          `第${siteConfig.edition}回 世田谷祭`,
+          siteConfig.metadata.siteName,
+          "東京都市大学 世田谷祭",
+        ],
+        description: siteConfig.description,
+        inLanguage: "ja",
+        publisher: { "@id": organizationId },
+      },
+      {
+        "@type": "Organization",
+        "@id": organizationId,
+        name: siteConfig.organization.name,
+        alternateName: siteConfig.organization.currentName,
+        url: siteUrl,
+        logo: {
+          "@type": "ImageObject",
+          url: logoUrl,
+          contentUrl: logoUrl,
+          width: 500,
+          height: 500,
+        },
+        image: ogImageUrl,
+        sameAs: Object.values(siteConfig.sns),
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: "玉堤1-28-1",
+          addressLocality: "世田谷区",
+          addressRegion: "東京都",
+          postalCode: "158-8557",
+          addressCountry: "JP",
+        },
+      },
+      {
+        "@type": "Event",
+        "@id": festivalId,
+        name: siteConfig.name,
+        alternateName: `第${siteConfig.edition}回 世田谷祭`,
+        description: siteConfig.description,
+        url: siteUrl,
+        image: [ogImageUrl],
+        startDate: `${siteConfig.dates.day1}T${siteConfig.openTime}:00+09:00`,
+        endDate: `${siteConfig.dates.day2}T${siteConfig.closeTime}:00+09:00`,
+        eventStatus: "https://schema.org/EventScheduled",
+        eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+        location: {
+          "@type": "Place",
+          name: siteConfig.venue,
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: "玉堤1-28-1",
+            addressLocality: "世田谷区",
+            addressRegion: "東京都",
+            postalCode: "158-8557",
+            addressCountry: "JP",
+          },
+        },
+        organizer: { "@id": organizationId },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## 概要

第96回アーカイブの検索除外と並行し、`setagayafes.org` が今年の公式サイトとして解釈されるためのシグナルを強化します。

Closes #111

## 変更内容

- ホームの構造化データを `WebSite / Organization / Event` の接続済み `@graph` に変更
- 検索結果のサイト名候補を、年次をまたいで一貫する「世田谷祭」に統一
- 第97回の正式名称、2026年開催日時、会場、主催、公式SNS、今年のロゴを構造化データへ追加
- Open Graphのサイト名と発行者情報を統一
- SNS URLから共有用クエリを除去して公式URLへ正規化
- 第96回アーカイブのnoindex/Search Console運用をdocsへ記録

## 検証

- `pnpm exec prettier --check ...`
- `pnpm lint`（エラー0、変更前からの警告7件）
- `pnpm build`
- `git diff --check`
- production buildを実ブラウザで確認
  - title / h1 / canonical / favicon / `og:site_name`
  - `WebSite / Organization / Event` JSON-LD
  - 内部リンクとconsole errorなし

## 公開後

- 最新mainのSHAでVercel Productionを新規ビルド
- 公開HTMLとHTTP応答を再検証
- Search Consoleで主要URLの再クロールと `sitemap.xml` 再送信
- 96thホストをnoindex化後、Search Consoleの一時削除を申請