### PR TITLE
PERF: ヒーロー見出しに Kaisei Opti サブセットを自前配信する（未検証・退避）

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,8 +132,15 @@ body {
    * 1番目: 上記サブセット（自前配信・8文字・即時）
    * 2番目: 遅延読み込み済みの next/font 版（トップ以外のページ向けの保険）
    * 3番目: 端末の明朝
+   *
+   * IMPORTANT: var() のフォールバックを省いてはいけない。
+   * --font-kaisei-opti は DeferredKaiseiFontsLoader が body へ class を足して
+   * 初めて定義されるが、トップページ (`/`) では意図的に読み込まれない。
+   * 未定義の var() をフォールバック無しで書くと、宣言全体が「計算値時に無効」となり
+   * font-family が body の --font-sans を継承してしまう（実測で踏んだ）。
    */
-  font-family: "Kaisei Opti Hero", var(--font-kaisei-opti), "Hiragino Mincho ProN", serif;
+  font-family:
+    "Kaisei Opti Hero", var(--font-kaisei-opti, "Kaisei Opti"), "Hiragino Mincho ProN", serif;
   font-weight: 700;
 }
 


### PR DESCRIPTION
> [!WARNING]
> **これは作業を失わないための退避ブランチです。私が書いたコードではなく、動作検証もしていません。** 作者が内容を確認したうえで Ready にしてください。

## 経緯

PR #89 の作業中、`git add -A` が作業ツリーに残っていたこの未コミット作業を巻き込みました。#89 のスコープから取り除くにあたり、**消さずに git 履歴へ残すため**このブランチへ退避したものです。

現時点で:

- `main` には入っていません
- 作業ツリーでも再開されていません（別の作業に移っている様子）
- `main` との差分は2ファイルのみで、他の変更は混じっていません

## 変更内容

```
public/fonts/kaisei-opti-hero-700.woff2 | Bin 0 -> 2832 bytes
src/app/globals.css                     |  47 +++++++++++++++++++++++++--
```

「第97回世田谷祭」の8文字だけを含む Kaisei Opti 700 のサブセット（2,832バイト）を自前配信し、`font-hero-display` をそれに差し替えるもの。コード内コメントによれば意図は以下です。

- `next/font` 版は `DeferredKaiseiFontsLoader` が読むが、トップページ (`/`) では初期表示を優先して意図的に読み込まない
- そのため見出しをそちらに頼ると、最も目立つ要素でフォント切り替わりが起きる
- サブセットを直接配信すれば、追加のCSSチャンクもレンダーブロッキングも無しに確定描画できる

`var()` のフォールバック（`var(--font-kaisei-opti, "Kaisei Opti")`）も含みます。未定義の `var()` をフォールバック無しで書くと宣言全体が無効化され `--font-sans` を継承する、という実測に基づく修正です。

## 確認が必要な点

- [ ] 実機でヒーロー見出しが Kaisei Opti で描画されるか
- [ ] `unicode-range` が「第97回世田谷祭」の8文字と一致しているか（第98回では woff2 の作り直しが必要）
- [ ] `main` 側の `--font-serif` / `--font-heading` の `var()` フォールバック対応と重複・矛盾がないか
- [ ] Lighthouse の LCP に想定どおり効いているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uPE8iKfYUSnDvKX12bNFn