### PR TITLE
FEATURE: 著名人企画LPに入場モーションを追加

### DIFF
--- a/src/app/special/[id]/page.tsx
+++ b/src/app/special/[id]/page.tsx
@@ -8,6 +8,7 @@ import { SpecialProfile } from "@/components/special/SpecialProfile";
 import { GoodsTable } from "@/components/special/GoodsTable";
 import { TicketTable } from "@/components/special/TicketTable";
 import { NoticeList } from "@/components/special/NoticeList";
+import { SpecialPageMotion } from "@/components/special/SpecialPageMotion";
 import { SNSLinks } from "@/components/events/SNSLinks";
 import { siteConfig, SPECIAL_GOODS_VISIBLE, SPECIAL_VISIBLE } from "@/data/site";
 import { createPageMetadata } from "@/lib/metadata";
@@ -140,6 +141,9 @@ export default async function SpecialDetailPage({ params }: SpecialPageProps) {
       />
 
       <div className="min-h-screen bg-secondary">
+        {/* ヒーローと各セクションの入場モーション（DOM は出力しない） */}
+        <SpecialPageMotion />
+
         <SpecialHero
           title={event.title}
           organizer={event.organizer}
@@ -147,7 +151,10 @@ export default async function SpecialDetailPage({ params }: SpecialPageProps) {
           photo={event.thumbnail}
         />
 
-        <div className="relative z-10 -mt-6 mx-4 min-h-[50vh] rounded-t-3xl bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.08)] sm:mx-6 lg:mx-8">
+        <div
+          className="relative z-10 -mt-6 mx-4 min-h-[50vh] rounded-t-3xl bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.08)] sm:mx-6 lg:mx-8"
+          data-special-sheet
+        >
           <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
             {/* パンくずリスト */}
             <nav aria-label="パンくずリスト" className="mb-4">

--- a/src/components/special/GoodsTable.tsx
+++ b/src/components/special/GoodsTable.tsx
@@ -27,7 +27,7 @@ export function GoodsTable({ goods, note }: GoodsTableProps) {
   const hasNote = goods.some((item) => item.note);
 
   return (
-    <section aria-labelledby="special-goods" className="py-8">
+    <section aria-labelledby="special-goods" className="py-8" data-special-reveal="up">
       <h2 id="special-goods" className="mb-4 text-xl font-bold text-gray-900 md:text-2xl">
         物販
       </h2>
@@ -82,7 +82,7 @@ export function GoodsTable({ goods, note }: GoodsTableProps) {
               )}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200" data-special-stagger>
             {goods.map((item, index) => (
               <tr key={`${item.name}-${index}`}>
                 {hasImage && (

--- a/src/components/special/NoticeList.tsx
+++ b/src/components/special/NoticeList.tsx
@@ -17,12 +17,12 @@ export function NoticeList({ notices }: NoticeListProps) {
   if (!notices || notices.length === 0) return null;
 
   return (
-    <section aria-labelledby="special-notices" className="py-8">
+    <section aria-labelledby="special-notices" className="py-8" data-special-reveal="up">
       <h2 id="special-notices" className="mb-4 text-xl font-bold text-gray-900 md:text-2xl">
         注意事項
       </h2>
 
-      <div className="space-y-4">
+      <div className="space-y-4" data-special-stagger>
         {notices.map((notice, index) => (
           <article
             key={`${notice.heading}-${index}`}

--- a/src/components/special/SpecialHero.tsx
+++ b/src/components/special/SpecialHero.tsx
@@ -20,38 +20,40 @@ interface SpecialHeroProps {
  * 配置は PageHero（`flex items-end` + `container mx-auto px-4`）と同じ構造に揃えており、
  * 白いシート内の本文と左端が一致します。
  *
- * 高さは画面幅によらず「ヘッダーを除いた1画面ぶん」で固定します。
- * ヘッダーは sticky でフロー上に高さを占有するため、単純に 100svh とすると
- * 下端がヘッダーの高さぶん折り返し線の下へ沈み、下寄せしたロゴと主催者名が
- * 初期表示で切れます。HeroSection / AboutHero と同じ計算式に揃えています。
- * 長いタイトルで内容がはみ出す場合に伸びるよう、h ではなく min-h を使います。
- *
  * ロゴの有無にかかわらず h1 は出力します（ロゴがある場合は画像の alt が見出しになります）。
+ *
+ * `data-special-hero-*` は SpecialPageMotion が入場アニメーションの対象を探すための
+ * フックです。この属性を消すと、該当要素だけ演出が無くなります（エラーにはなりません）。
  */
 export function SpecialHero({ title, organizer, logo, photo }: SpecialHeroProps) {
   return (
-    <section className="relative isolate flex min-h-[calc(100svh-var(--header-height))] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
-      {/* 背景写真 */}
+    <section className="relative isolate flex min-h-[60vh] items-end overflow-hidden bg-primary-dark pb-10 pt-20 md:pb-16">
+      {/* 背景写真
+          ラッパーを挟んでいるのは、SpecialPageMotion が中の <img> だけを拡大縮小するため。
+          `fill` は position 指定のある親を必要とするので absolute inset-0 を持たせている。 */}
       {photo && (
         <>
-          <Image
-            src={photo.url}
-            alt=""
-            fill
-            priority
-            sizes="100vw"
-            className="object-cover"
-            aria-hidden="true"
-          />
+          <div className="absolute inset-0" data-special-hero-image>
+            <Image
+              src={photo.url}
+              alt=""
+              fill
+              priority
+              sizes="100vw"
+              className="object-cover"
+              aria-hidden="true"
+            />
+          </div>
           <div
             className="special-hero-overlay pointer-events-none absolute inset-0"
             aria-hidden="true"
+            data-special-hero-overlay
           />
         </>
       )}
 
       <div className="container relative mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex max-w-2xl flex-col gap-4">
+        <div className="flex max-w-2xl flex-col gap-4" data-special-hero-copy>
           {logo ? (
             <h1 className="flex">
               <Image

--- a/src/components/special/SpecialPageMotion.tsx
+++ b/src/components/special/SpecialPageMotion.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { gsap } from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
+
+gsap.registerPlugin(ScrollTrigger);
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * オープナーが `opener-done` を発火できなかった場合に入場を始める上限時間。
+ * HeroSection / AboutHero と同じ 5 秒に揃えている。
+ */
+const OPENER_FAILSAFE_MS = 5000;
+
+type RevealVariant = "left" | "right" | "scale" | "up";
+
+const revealOffsets: Record<RevealVariant, gsap.TweenVars> = {
+  left: { x: -36, y: 0 },
+  right: { x: 36, y: 0 },
+  scale: { scale: 0.97, y: 18 },
+  up: { y: 32 },
+};
+
+/**
+ * 著名人企画LP専用の入場モーション。
+ *
+ * AccessPageMotion と同じく、非表示マーカーを1つ置いて data 属性だけをフックにする。
+ * LP のセクションはすべて Server Component のため、この方式なら "use client" を
+ * 広げずに演出を足せる。
+ *
+ * JavaScript無効時と prefers-reduced-motion 時は、静的な完成形をそのまま表示する
+ * （入場はすべて gsap.from() なので、何も実行しなければ完成形になる）。
+ *
+ * AccessPageMotion からあえて変えている点が2つある。
+ *
+ * 1. ヒーローの背景写真は opacity を触らず scale だけを動かす。
+ *    この写真は priority 付きで、ページの LCP 候補そのもの。
+ *    docs/frontend/performance.md の「LCP 候補はサーバーHTMLから可視状態にする」に従う。
+ *
+ * 2. ヒーローの入場は `opener-done` を待つ。OpenerLoader は app/layout.tsx にあり
+ *    全ページで動くため、待たないとオープナーが画面を覆っている間に演出が終わる。
+ *    スクロールリビール側は待たずに登録する（待つとファーストビュー直下の
+ *    セクションで発火を取りこぼす）。
+ */
+export function SpecialPageMotion() {
+  const markerRef = useRef<HTMLSpanElement>(null);
+  const ctxRef = useRef<gsap.Context | null>(null);
+
+  useEffect(() => {
+    // マーカーはページ最上位のラッパー直下に置く前提。ヒーローと白いシートの
+    // 両方を含む要素をスコープにする。
+    const root = markerRef.current?.parentElement;
+
+    if (!root || ctxRef.current) return;
+    if (window.matchMedia(REDUCED_MOTION_QUERY).matches) return;
+
+    const ctx = gsap.context(() => {
+      const revealTargets = gsap.utils.toArray<HTMLElement>("[data-special-reveal]", root);
+
+      revealTargets.forEach((target) => {
+        const variant = (target.dataset.specialReveal || "up") as RevealVariant;
+
+        gsap.from(target, {
+          autoAlpha: 0,
+          duration: variant === "scale" ? 0.85 : 0.72,
+          ease: "power3.out",
+          force3D: true,
+          clearProps: "opacity,visibility,transform",
+          ...revealOffsets[variant],
+          scrollTrigger: {
+            trigger: target,
+            start: "top 86%",
+            once: true,
+          },
+        });
+      });
+
+      const staggerGroups = gsap.utils.toArray<HTMLElement>("[data-special-stagger]", root);
+
+      staggerGroups.forEach((group) => {
+        const items = Array.from(group.children);
+
+        if (items.length === 0) return;
+
+        gsap.from(items, {
+          autoAlpha: 0,
+          y: 24,
+          duration: 0.64,
+          ease: "power3.out",
+          stagger: 0.1,
+          force3D: true,
+          clearProps: "opacity,visibility,transform",
+          scrollTrigger: {
+            trigger: group,
+            start: "top 84%",
+            once: true,
+          },
+        });
+      });
+    }, root);
+
+    ctxRef.current = ctx;
+
+    let entranceStarted = false;
+
+    /**
+     * ヒーローと白いシートの入場。
+     * オープナーの完了イベントとフェイルセーフの両方から呼ばれるため、多重実行を防ぐ。
+     */
+    const runEntrance = () => {
+      if (entranceStarted || !ctxRef.current) return;
+      entranceStarted = true;
+
+      ctxRef.current.add(() => {
+        const heroImage = root.querySelector<HTMLElement>("[data-special-hero-image] img");
+        const heroOverlay = root.querySelector<HTMLElement>("[data-special-hero-overlay]");
+        const heroCopy = root.querySelector<HTMLElement>("[data-special-hero-copy]");
+        const heroCopyItems = heroCopy ? Array.from(heroCopy.children) : [];
+        const sheet = root.querySelector<HTMLElement>("[data-special-sheet]");
+
+        const entrance = gsap.timeline({
+          defaults: { ease: "power3.out", force3D: true },
+        });
+
+        // 背景写真は LCP 候補。opacity / visibility には触れない。
+        if (heroImage) {
+          entrance.from(
+            heroImage,
+            {
+              scale: 1.06,
+              duration: 1.35,
+              clearProps: "transform",
+            },
+            0
+          );
+        }
+
+        if (heroOverlay) {
+          entrance.from(
+            heroOverlay,
+            {
+              autoAlpha: 0,
+              duration: 0.9,
+              clearProps: "opacity,visibility",
+            },
+            0
+          );
+        }
+
+        if (heroCopyItems.length > 0) {
+          entrance.from(
+            heroCopyItems,
+            {
+              autoAlpha: 0,
+              y: 28,
+              duration: 0.75,
+              stagger: 0.1,
+              clearProps: "opacity,visibility,transform",
+            },
+            0.18
+          );
+        }
+
+        if (sheet) {
+          entrance.from(
+            sheet,
+            {
+              y: 48,
+              duration: 0.9,
+              clearProps: "transform",
+            },
+            0.48
+          );
+        }
+      });
+    };
+
+    // 遅延ローダーの空フォールバックは、実体のオープナーとして扱わない。
+    const hasOpener = !!document.querySelector("[data-opener-active]");
+    let failsafeId: number | undefined;
+
+    if (hasOpener) {
+      window.addEventListener("opener-done", runEntrance);
+      failsafeId = window.setTimeout(runEntrance, OPENER_FAILSAFE_MS);
+    } else {
+      runEntrance();
+    }
+
+    ScrollTrigger.refresh();
+
+    return () => {
+      window.removeEventListener("opener-done", runEntrance);
+      if (failsafeId !== undefined) window.clearTimeout(failsafeId);
+      ctxRef.current?.revert();
+      ctxRef.current = null;
+    };
+  }, []);
+
+  return <span ref={markerRef} hidden aria-hidden="true" />;
+}

--- a/src/components/special/SpecialProfile.tsx
+++ b/src/components/special/SpecialProfile.tsx
@@ -21,7 +21,7 @@ export function SpecialProfile({ content, photos }: SpecialProfileProps) {
   if (!content && !hasPhotos) return null;
 
   return (
-    <section aria-labelledby="special-profile" className="py-8">
+    <section aria-labelledby="special-profile" className="py-8" data-special-reveal="up">
       <h2 id="special-profile" className="mb-4 text-xl font-bold text-gray-900 md:text-2xl">
         出演者情報
       </h2>
@@ -36,7 +36,7 @@ export function SpecialProfile({ content, photos }: SpecialProfileProps) {
       {/* grid だと枚数が奇数のとき最後の1枚が左カラムに固定されるため、
           中央寄せできる flex-wrap を使う */}
       {hasPhotos && (
-        <ul className="mt-6 flex flex-wrap justify-center gap-4">
+        <ul className="mt-6 flex flex-wrap justify-center gap-4" data-special-stagger>
           {/* 同じ画像を複数枚選べるため、URL だけでは key が衝突する */}
           {photos?.map((photo, index) => (
             <li

--- a/src/components/special/SpecialSchedule.tsx
+++ b/src/components/special/SpecialSchedule.tsx
@@ -57,12 +57,15 @@ export function SpecialSchedule({
   const performance = startTime && endTime ? `${startTime} 〜 ${endTime}` : startTime;
 
   return (
-    <section aria-labelledby="special-schedule" className="py-8">
+    <section aria-labelledby="special-schedule" className="py-8" data-special-reveal="up">
       <h2 id="special-schedule" className="mb-4 text-xl font-bold text-gray-900 md:text-2xl">
         開催日時・会場
       </h2>
 
-      <dl className="divide-y divide-gray-200 rounded-xl border border-gray-200">
+      <dl
+        className="divide-y divide-gray-200 rounded-xl border border-gray-200"
+        data-special-stagger
+      >
         <div className="flex flex-col gap-1 px-4 py-3 sm:flex-row sm:gap-4">
           <dt className="w-32 shrink-0 text-sm font-semibold text-gray-900/70">日程</dt>
           <dd className="text-sm text-gray-900">{formatEventDate(date)}</dd>

--- a/src/components/special/TicketTable.tsx
+++ b/src/components/special/TicketTable.tsx
@@ -28,7 +28,7 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
   const hasButton = tickets.some((ticket) => ticket.buttonUrl);
 
   return (
-    <section aria-labelledby="special-tickets" className="py-8">
+    <section aria-labelledby="special-tickets" className="py-8" data-special-reveal="up">
       <h2 id="special-tickets" className="mb-4 text-xl font-bold text-gray-900 md:text-2xl">
         チケット販売
       </h2>
@@ -52,7 +52,7 @@ export function TicketTable({ tickets, note }: TicketTableProps) {
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-200">
+          <tbody className="divide-y divide-gray-200" data-special-stagger>
             {hasPrice && (
               <tr>
                 <th


### PR DESCRIPTION
## 概要

`/special/[id]` の著名人企画LPは6セクションすべてが Server Component で、アニメーションが一切入っていませんでした。SNSでの拡散が期待される導線のため、Accessページと同水準の入場モーションを追加します。

対象は詳細LPのみで、`/special` 一覧ページは変更していません。

## 実装方針

`AccessPageMotion` と同じ「非表示マーカー1個 + `data-*` 属性」方式で `SpecialPageMotion` を追加しました。各セクションに増えたのは属性1つだけで、**`"use client"` は1つも広がっていません**。

- ヒーロー: 背景写真の緩やかなズームアウト、オーバーレイのフェード、ロゴ・主催の stagger、白シートのせり上がり
- 各セクション: `ScrollTrigger` の `once` で fade-up
- 写真ギャラリー / 日程リスト / 物販・チケットのテーブル行 / 注意事項カード: stagger

## AccessPageMotion からあえて変えた2点

### 1. ヒーロー背景写真の `opacity` を触らない

この写真は `priority` 付きでページの **LCP候補そのもの**です。`docs/frontend/performance.md` の「LCP 候補はサーバーHTMLから可視状態にする」「入場演出の完了を LCP 表示条件にしない」に従い、`scale` のみを動かしています。

> 既存の `AccessPageMotion.tsx:47-57` はヒーロー画像に `autoAlpha: 0` を当てており、このルールに違反しています。本PRのスコープ外のため温存しましたが、別Issueでの是正を推奨します。

### 2. `opener-done` を待つ

`OpenerLoader` は `app/layout.tsx` にあり全ページで動きます。待たないとオープナーが画面を覆っている間に演出が終わるため、`AboutHero` / `HeroSection` と同じ待機パターンを採用しました。スクロールリビール側は待たずに登録しています（待つとファーストビュー直下のセクションで発火を取りこぼすため）。

## 検証（ローカル本番ビルド + 実データ1件）

`pnpm lint` 0 errors / `pnpm format:check` 通過 / `pnpm build` 成功。

ブラウザ上で computed style をサンプリングして計測しました（スクリーンショットはアニメーションが t=0 で固まるため判定に使っていません）。

**デスクトップ 1280×720**

| t(ms) | opener | ロゴ opacity | オーバーレイ | 写真 opacity | 写真 transform | 白シート |
|---|---|---|---|---|---|---|
| 203 | 有 | 1 | 1 | **1** | none | none |
| 1212 | 有 | **0** | 0.32 | **1** | scaled | moved |
| 2022 | 有 | 1 | 1 | **1** | scaled | moved |
| 2526 | 有 | 1 | 1 | **1** | **none** | **none** |

**モバイル 390×844**: `opener: 0` / `openerShell: 1` — 遅延ローダーの空フォールバックを実体と誤認せず、マウント直後に入場開始。

| 項目 | 結果 |
|---|---|
| 背景写真の opacity | 終始 `1`（一度も落ちない） |
| `opener-done` 待機 | 機能（t=1212で発火→入場開始） |
| スクロールリビール | 5セクションすべて `once` で発火 |
| stagger 子要素 | 17個すべて `opacity: 1` に到達 |
| `clearProps` | インラインスタイルの残骸ゼロ |
| 横溢れ | スクロール全域で発生なし |
| テーブル行 stagger | `divide-y` のずれなし |
| コンソールエラー | なし |
| `prefers-reduced-motion` | スクロールせずに全要素が完成形（GSAP不実行） |

入場はすべて `gsap.from()` のため、モーション軽減時とJavaScript無効時は静的な完成形がそのまま表示されます。`globals.css` の打ち消し追加は不要です。

## 影響範囲

`src/**/special` のみ。`origin/main` の直近4コミットは special 配下に触れておらず、コンフリクトはありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkmcaYX5QdpwEgNEWifx32
