### PR TITLE
FIX: 協賛ロゴ列のフォールバック時に両端フェードが効かない問題を修正

### DIFF
--- a/src/components/home/SponsorLogoLoop.tsx
+++ b/src/components/home/SponsorLogoLoop.tsx
@@ -113,8 +113,6 @@ export function SponsorLogoLoop({ sponsors, onReady }: SponsorLogoLoopProps) {
         pauseOnHover
         logoHeight={40}
         gap={48}
-        fadeOut
-        fadeOutColor="#ffffff"
         ariaLabel="協賛企業ロゴ"
         renderItem={renderItem}
       />

--- a/src/components/home/SponsorLogoLoopLoader.tsx
+++ b/src/components/home/SponsorLogoLoopLoader.tsx
@@ -95,6 +95,17 @@ export function SponsorLogoLoopLoader({ sponsors }: { sponsors: Information[] })
           <SponsorLogoLoop sponsors={sponsors} onReady={handleReady} />
         </div>
       )}
+      {/* 両端のフェード。静的フォールバックと LogoLoop 本体のどちらが表示されていても
+          同じ見え方になるよう、ローダー側で1組だけ持つ。LogoLoop の fadeOut は使わない
+          （同じグラデを2枚重ねると中間が濃くなる）。幅は LogoLoop.css の fade と揃えている。 */}
+      <div
+        className="pointer-events-none absolute inset-y-0 left-0 z-20 w-[clamp(24px,8%,120px)] bg-gradient-to-r from-white to-white/0"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute inset-y-0 right-0 z-20 w-[clamp(24px,8%,120px)] bg-gradient-to-l from-white to-white/0"
+        aria-hidden="true"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 問題

協賛企業のロゴ列は、初期表示では静的な `<ul>`（`StaticSponsorLogos`）を出し、IntersectionObserver の発火後に `LogoLoop` へ差し替える progressive enhancement です。

`fadeOut` は `LogoLoop` 側にしか無いため、**差し替わる前は両端のロゴが切り落とされたまま**表示されていました。ビューポートに入るまで本体はロードされないので、スクロールで最初に目に入るのは常にフォールバックのほうです。

## 修正

フェードを `SponsorLogoLoopLoader` のルートに1組だけ持たせ、フォールバック・本体のどちらの状態でも同じ見え方にします。

- `LogoLoop` 側の `fadeOut` / `fadeOutColor` は削除しました。同じグラデーションを2枚重ねると中間が濃くなるためです
- 幅は `clamp(24px, 8%, 120px)` とし、`LogoLoop.css` の `.logoloop--fade` と揃えています
- 終端は `to-transparent` ではなく `to-white/0` です。`transparent` キーワードは `rgba(0,0,0,0)` として補間されるため、白からのグラデーションが灰色を経由してしまいます

## 検証

- `pnpm lint`（新規の指摘なし）、`pnpm format:check`、`tsc --noEmit` 通過
- ブラウザで両端がフェードすることを確認。フェード要素が2枚あり、`.logoloop--fade` が消えていることを DOM で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Co3nHCVFUGDwDpo6Tz1Nem
