### PR TITLE
FIX: OGP画像を1200x630のレターボックスに整えて被写体の欠けを防ぐ

### DIFF
--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -42,19 +42,73 @@ function absoluteUrl(pathOrUrl: string): string {
   return new URL(pathOrUrl, siteConfig.metadata.siteUrl).toString();
 }
 
+/** OGP カードが期待する標準サイズ */
+const OGP_IMAGE_WIDTH = 1200;
+const OGP_IMAGE_HEIGHT = 630;
+
+/** microCMS の画像配信ホスト */
+const MICROCMS_IMAGE_HOST = "images.microcms-assets.io";
+
+/**
+ * レターボックスの余白色。globals.css の `--color-primary-600` と同値。
+ * `#` を付けないのは microCMS（imgix 準拠）の `fill-color` の記法に合わせるため。
+ */
+const OGP_FILL_COLOR = "8E3AB0";
+
+/**
+ * microCMS の画像を OGP 用の 1200x630 に整える
+ *
+ * サムネイルの比率は入稿者に委ねられており、著名人企画は正方形で入稿されている。
+ * `twitter:card = summary_large_image` は 2:1 前後を想定するため、正方形をそのまま
+ * 渡すと上下が切り落とされ、人物写真では頭部が欠ける。
+ *
+ * `fit=fill` で 1200x630 のキャンバス中央へ画像全体を収め、余った左右（縦長なら
+ * 上下）をブランドカラーで埋める。トリミングしないので、どの比率で入稿されても
+ * 被写体が欠けない。
+ *
+ * microCMS 以外のURL（`/ogp.webp` などの静的ファイル）は変換せずに返す。
+ */
+function toOgpImageUrl(url: string): string {
+  let parsed: URL;
+
+  try {
+    parsed = new URL(url, siteConfig.metadata.siteUrl);
+  } catch {
+    return url;
+  }
+
+  if (parsed.hostname !== MICROCMS_IMAGE_HOST) return url;
+
+  parsed.searchParams.set("w", String(OGP_IMAGE_WIDTH));
+  parsed.searchParams.set("h", String(OGP_IMAGE_HEIGHT));
+  parsed.searchParams.set("fit", "fill");
+  parsed.searchParams.set("fill", "solid");
+  parsed.searchParams.set("fill-color", OGP_FILL_COLOR);
+
+  return parsed.toString();
+}
+
 function buildImages(image: MetadataImage | undefined, title: string) {
   const source = image ?? {
     url: siteConfig.metadata.ogImage,
-    width: 1200,
-    height: 630,
+    width: OGP_IMAGE_WIDTH,
+    height: OGP_IMAGE_HEIGHT,
     alt: title,
   };
   const normalized = typeof source === "string" ? { url: source } : source;
+  const ogpUrl = toOgpImageUrl(normalized.url);
+  /*
+   * 変換したときだけ寸法を上書きする。入稿時の実寸（例: 1280x1280）を残すと、
+   * 実体が 1200x630 なのに SNS 側が正方形の領域を確保してしまう。
+   */
+  const isConverted = ogpUrl !== normalized.url;
 
   return [
     {
       ...normalized,
-      url: absoluteUrl(normalized.url),
+      url: absoluteUrl(ogpUrl),
+      width: isConverted ? OGP_IMAGE_WIDTH : normalized.width,
+      height: isConverted ? OGP_IMAGE_HEIGHT : normalized.height,
       alt: normalized.alt ?? title,
     },
   ];


### PR DESCRIPTION
## 概要

SNS カードで被写体が欠ける問題を修正します。**本日が著名人企画の解禁日**で拡散が見込まれるため、先行して直します。

著名人企画 MON7A のアーティスト写真は **正方形（1280×1280）** で入稿されています。一方 `twitter:card = summary_large_image` は 2:1 前後を想定するため、そのまま渡すと上下が切り落とされ、**頭頂部が完全に欠けます**。

実際の生成結果を並べると差は明らかです（クリックで実物が開きます）。

| 現状（切れる） | 本PR（切れない） |
| --- | --- |
| [`fit=crop`](https://images.microcms-assets.io/assets/e2c3a1c035834ec198750609b56213a0/b6818dee87034adc9a1794d143bd8cdc/S__26755118.jpg?w=1200&h=630&fit=crop) — 髪の上部と衣装の下部が欠落 | [`fit=fill`](https://images.microcms-assets.io/assets/e2c3a1c035834ec198750609b56213a0/b6818dee87034adc9a1794d143bd8cdc/S__26755118.jpg?w=1200&h=630&fit=fill&fill=solid&fill-color=8E3AB0) — 全体が収まり左右がブランドカラー |

## 変更内容

`src/lib/metadata.ts` の `buildImages()` に `toOgpImageUrl()` を追加しました。**変更は1ファイルのみ**です。

- microCMS ホスト（`images.microcms-assets.io`）の画像だけを `?w=1200&h=630&fit=fill&fill=solid&fill-color=8E3AB0` で変換
- 余白色 `8E3AB0` は `globals.css` の `--color-primary-600` と同値。`#` を付けないのは imgix の `fill-color` の記法に合わせるため
- 静的な `/ogp.webp` を使うページは変換せず素通し
- 変換したときだけ `og:image:width` / `height` を 1200×630 で上書き。入稿実寸（1280×1280）を残すと、実体が 2:1 なのに SNS 側が正方形の領域を確保するため

## 設計上の判断

- **トリミングではなくレターボックス。** `fit=crop` は 2:1 に収まりますが人物写真では顔が切れます。`fit=fill` なら入稿比率が縦長でも横長でも被写体が欠けません
- **`buildImages()` で一括対応。** microCMS のサムネイルを OGP に渡しているのは `/events/[id]` `/info/[id]` `/special/[id]` の3ページで、すべて同じコードパスです。個別に直すと取りこぼします
- **ホスト判定で限定。** `new URL()` で解析し、microCMS 以外は無変換で返します。解析に失敗した場合も元の文字列をそのまま返します

## 検証

`pnpm lint`（エラー0／既存の警告7件のみ）、`pnpm format:check`、`tsc --noEmit`、`pnpm build` 通過。

ローカル（`next dev`）で生成メタタグを実測しました。

| 対象 | 結果 |
| --- | --- |
| LP の `og:image` | 変換パラメータが付与される |
| LP の `og:image:width` / `height` | `1200` / `630` |
| LP の `twitter:image` | 同様に変換される |
| `/` `/special` `/access` の `og:image` | `/ogp.webp` のまま **素通し** |

生成された URL の実体も確認しました。`HTTP 200` / `image/jpeg` / 81KB、**JPEG の SOF マーカーから読んだ実寸が 1200×630（1.90:1）**。属性値ではなくバイナリで確認しています。

## 注意

- 本番の `/special/special-event-mon7a` は既に公開中です。マージ後、ISR（`revalidate = 600`）により最大10分で新しい `og:image` に切り替わります
- X / Facebook はカード情報をキャッシュします。反映後に **Card Validator でキャッシュを更新**してください
- 既に投稿済みのポストのカードは、キャッシュが切れるまで旧画像のままです

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkmcaYX5QdpwEgNEWifx32
