### PR TITLE
FEATURE: /97th/about と /special を著名人企画LPへ302で転送する

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,9 +240,9 @@ push 時は head をそのまま、PR 時は head を base へマージした結
 /                           # トップページ (HOME)
 ├── /events                 # 企画を探す
 │   ├── /                   # 企画検索・一覧
-│   └── /[id]               # 企画詳細 [動的生成] ※type=special は /special/[id] へ 308
+│   └── /[id]               # 企画詳細 [動的生成] ※type=special は /special/[id] へ誘導（下記の注意）
 ├── /special                # 著名人企画
-│   ├── /                   # 一覧
+│   ├── /                   # 一覧（現在は /special/[id] へ 302。下記の注意）
 │   └── /[id]               # 著名人企画LP [動的生成]
 ├── /timetable              # タイムテーブル
 ├── /access                 # キャンパスマップ（2D）+ 交通アクセス
@@ -259,6 +259,37 @@ push 時は head をそのまま、PR 時は head を base へマージした結
 │   └── /privacy            # プライバシーポリシー
 └── /[locale]               # 多言語ページ (en, zh, ko)
 ```
+
+### リダイレクトはページ内 `redirect()` で実装しないこと（重要）
+
+**このアプリでは Server Component 内の `redirect()` が HTTP リダイレクトにならない。**
+ルート直下の `src/app/loading.tsx` によりストリーミングのシェルが先に送出されるため、
+ページのレンダリング中に投げた `redirect()` はステータスコードに反映されず、
+`<meta http-equiv="refresh" content="1;url=...">` へ格下げされる。
+結果は **HTTP 200 + 1秒待ってからのクライアント遷移**になる。
+`export const dynamic = "force-dynamic"` を足しても変わらない（2026-08-29 実測）。
+
+本物のリダイレクトを返せる層は次の2つだけである。
+
+| 層                                | 用途                                                   |
+| --------------------------------- | ------------------------------------------------------ |
+| `next.config.ts` の `redirects()` | 静的に決まる転送。動的ルートの照合より先に走る（推奨） |
+| `src/proxy.ts`                    | リクエスト内容を見て決める必要がある転送               |
+
+現在の転送一覧と設計判断は [`docs/dev/domain-migration.md`](../docs/dev/domain-migration.md) を参照。
+
+> [!WARNING]
+> `src/app/events/[id]/page.tsx` の `type=special` → `/special/[id]` 誘導は
+> ページ内 `redirect()` のままであり、上記のとおり 200 + meta refresh になっている。
+> 未解消（要Issue）。
+
+### 未知のロケールセグメントが 200 を返す問題（未解消）
+
+`src/app/[locale]/` の `[locale]` は任意の文字列にマッチするため、
+`/foo/about` や `/hoge/access` が 404 ではなく `/about`・`/access` と同じ内容を
+200 で返している。`src/app/[locale]/layout.tsx` の `notFound()` はストリーミングの
+シェル送出後に投げられるためステータスに反映されない。
+`/97th/about` だけは `next.config.ts` の 302 で個別に塞いだが、根本解決は未着手（要Issue）。
 
 ## 主要機能
 

--- a/docs/dev/domain-migration.md
+++ b/docs/dev/domain-migration.md
@@ -10,6 +10,7 @@
 | 第96回の退避先       | **`96th.setagayafes.org`**（さくらに残す）                    |
 | 旧URLの扱い          | `setagayafes.org/96th/*` → **301** → `96th.setagayafes.org/*` |
 | 旧委員会URLの扱い    | `setagayafes.org/sfa` → **301** → `setagayafes.org/about`     |
+| 告知用の旧URL        | `setagayafes.org/97th/about` → **302** → 著名人企画LP         |
 | `NEXT_PUBLIC_URL`    | `https://setagayafes.org`                                     |
 
 ## 現状
@@ -17,18 +18,19 @@
 > [!WARNING]
 > **移行作業は反映済み。** `setagayafes.org` はVercelの第97回サイト、`96th.setagayafes.org` はさくらの第96回WordPressを配信している。
 
-| 項目                            | 状態                                                                |
-| ------------------------------- | ------------------------------------------------------------------- |
-| Vercel のドメイン割当           | **完了**（`setagayafes.org` / `www.setagayafes.org` の両方）        |
-| `NEXT_PUBLIC_URL`               | **完了**（Vercel / GitHub Variables とも `setagayafes.org`）        |
-| `/96th/*` の 301                | **実装済み**（`src/proxy.ts` / `next.config.ts`）                   |
-| `/sfa` の 301                   | **実装済み**（`next.config.ts`、`/about`へ統合）                    |
-| `96th.setagayafes.org` の作成   | **完了**（さくら側、2026-08-24）                                    |
-| 第96回ファイルバックアップ      | **完了**（SnapUP、2026-08-24、正常終了）                            |
-| 第96回DBバックアップ            | **完了**（phpMyAdmin、2026-08-24、[検証台帳](./96th-db-backup.md)） |
-| 第96回サブドメインのSSL         | **完了**（Let's Encrypt、2026-08-24）                               |
-| WordPress の `siteurl` / `home` | **完了**（`https://96th.setagayafes.org`）                          |
-| `setagayafes.org` の DNS 切替   | **完了**（Vercel）                                                  |
+| 項目                             | 状態                                                                |
+| -------------------------------- | ------------------------------------------------------------------- |
+| Vercel のドメイン割当            | **完了**（`setagayafes.org` / `www.setagayafes.org` の両方）        |
+| `NEXT_PUBLIC_URL`                | **完了**（Vercel / GitHub Variables とも `setagayafes.org`）        |
+| `/96th/*` の 301                 | **実装済み**（`src/proxy.ts` / `next.config.ts`）                   |
+| `/sfa` の 301                    | **実装済み**（`next.config.ts`、`/about`へ統合）                    |
+| `/97th/about`・`/special` の 302 | **実装済み**（`next.config.ts`、著名人企画LPへ）                    |
+| `96th.setagayafes.org` の作成    | **完了**（さくら側、2026-08-24）                                    |
+| 第96回ファイルバックアップ       | **完了**（SnapUP、2026-08-24、正常終了）                            |
+| 第96回DBバックアップ             | **完了**（phpMyAdmin、2026-08-24、[検証台帳](./96th-db-backup.md)） |
+| 第96回サブドメインのSSL          | **完了**（Let's Encrypt、2026-08-24）                               |
+| WordPress の `siteurl` / `home`  | **完了**（`https://96th.setagayafes.org`）                          |
+| `setagayafes.org` の DNS 切替    | **完了**（Vercel）                                                  |
 
 ### 2026-08-24 の実施内容
 
@@ -62,6 +64,28 @@
 - 第97回の名称・開催日をdescriptionと `WebSite` JSON-LDで明示し、500×500のfaviconをmetadataから指定する。
 - Googlebotの大きな画像プレビューを許可し、トップと委員会紹介の代表画像をサイトマップへ追加する。
 - Production反映後、Search Consoleでトップ・`/about` のインデックス登録をリクエストし、`sitemap.xml` を再送信する。
+
+### 2026-08-29 の著名人企画への転送
+
+著名人企画（MON7A）の告知導線として、次の2本を `next.config.ts` の `redirects()` に追加した。
+
+| リクエスト    | ステータス | 転送先                                               |
+| ------------- | ---------- | ---------------------------------------------------- |
+| `/97th/about` | **302**    | `/special/<eventId>`（非公開時は `/special`）        |
+| `/special`    | **302**    | `/special/<eventId>`（`SPECIAL_VISIBLE` が真のとき） |
+
+いずれも末尾スラッシュ付き（`/97th/about/`）でも同じ1ホップで着地する。`source` は末尾スラッシュなしの1本だけでよい。
+
+**なぜ 301 ではなく 302 なのか。** `/96th`・`/sfa` の恒久移設と違い、これは会期限定の告知導線である。301 はブラウザが無期限にキャッシュするため、企画終了後に設定を外しても一度踏んだ端末では効き続ける。
+
+**なぜ `next.config.ts` なのか。** 理由は2つある。
+
+1. `/97th/about` は放置すると **404 ではなく 200 で `/about` の内容を返す**。`src/app/[locale]/about/page.tsx` の `[locale]` が `97th` をロケールとして飲み込むためで、`/foo/about` や `/hoge/access` でも同じ重複配信が起きる。`redirects()` は動的ルートの照合より先に走るため、ここで塞ぐのが確実である（`/97th` 以外の未知セグメントは未対応のまま残っている）。
+2. **ページ内の `redirect()` では代用できない。** ルート直下の `src/app/loading.tsx` によりストリーミングのシェルが先に送出され、ページのレンダリング中に投げた `redirect()` は HTTP ステータスに反映されず `<meta http-equiv="refresh" content="1;url=...">` へ格下げされる。`export const dynamic = "force-dynamic"` を足しても同じだった（実測）。**このアプリで本物の転送を返せるのは `next.config.ts` の `redirects()` と `src/proxy.ts` だけである。**
+
+転送先の企画IDは `src/data/special-banner.ts` の `eventId` を出典とする。トップページの告知セクションが参照しているものと同一で、設定側にベタ書きすると2箇所へ散るためである。非公開（`NEXT_PUBLIC_SPECIAL_VISIBLE` が真でない）の間は LP が `notFound()` を返すので、転送先を `/special` の準備中表示へ落とし、`/special` 自身の転送は出さない。
+
+**2組目の著名人企画が公開されたら `/special` のエントリを削除すること。** `src/app/special/page.tsx` の一覧表示がそのまま復帰する。`src/app/sitemap.ts` の `/special` 除外判定も併せて見直す。
 
 ## なぜ rewrite ではなく redirect なのか
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import bundleAnalyzer from "@next/bundle-analyzer";
+import { specialBanner } from "./src/data/special-banner";
 
 const withNextIntl = createNextIntlPlugin();
 const withBundleAnalyzer = bundleAnalyzer({
@@ -33,6 +34,26 @@ const withBundleAnalyzer = bundleAnalyzer({
  */
 const ARCHIVE_96TH_ORIGIN = "https://96th.setagayafes.org";
 
+/**
+ * 著名人企画LPへの転送先。
+ *
+ * ID の出典は `src/data/special-banner.ts` に一本化する。トップページの告知
+ * セクションが参照しているのと同じ「いま推している著名人企画」であり、ここで
+ * 別途ベタ書きすると 2 箇所に散る。`@/` エイリアスは next.config の読み込み時に
+ * 解決されないため、相対パスで取り込む（このモジュールは他を import しない
+ * 純粋なデータ定義なので、設定ファイルから読んでも副作用はない）。
+ *
+ * 公開フラグはビルド時に評価される。`src/data/site.ts` の SPECIAL_VISIBLE と
+ * 同じ判定式だが、そちらは `@/` 経由でしか読めないため式のみを再掲する。
+ */
+const SPECIAL_VISIBLE = process.env.NEXT_PUBLIC_SPECIAL_VISIBLE === "true";
+
+/**
+ * 非公開の間は LP が `notFound()` を返すため、転送先を `/special` の準備中表示に
+ * 落とす。ここを LP 直指しのままにすると、告知URLを踏んだ来場者が 404 に着く。
+ */
+const SPECIAL_LANDING_PATH = SPECIAL_VISIBLE ? `/special/${specialBanner.eventId}` : "/special";
+
 const nextConfig: NextConfig = {
   // `/96th/` の専用301をNext.jsの自動308より先に処理するため、
   // 末尾スラッシュの自動リダイレクトは proxy.ts で明示的に再現する。
@@ -57,6 +78,43 @@ const nextConfig: NextConfig = {
          */
         statusCode: 301,
       },
+      {
+        /*
+         * 旧・第97回サイトの委員会紹介URL。著名人企画の告知導線として再利用する。
+         *
+         * このURLは放置すると404ではなく200を返す。`src/app/[locale]/about/page.tsx`
+         * の `[locale]` が `97th` をロケールとして飲み込み、`/about` と同じ内容を
+         * 重複配信するためである。`redirects()` は動的ルートの照合より先に走るので、
+         * ここで塞ぐのが唯一の確実な層になる（proxy.ts の matcher では遅い）。
+         *
+         * `statusCode: 301` ではなく 302。301 はブラウザが無期限にキャッシュするため、
+         * 企画終了後にこの転送を外しても、一度踏んだ訪問者の端末では効き続ける。
+         */
+        source: "/97th/about",
+        destination: SPECIAL_LANDING_PATH,
+        statusCode: 302,
+      },
+      /*
+       * 公開中の著名人企画が1組だけの間、`/special` の一覧はカード1枚が並ぶだけに
+       * なるため、一覧を挟まず LP へ送る。非公開の間は `/special` 自身が準備中表示を
+       * 担うので転送しない。
+       *
+       * ページ側の `redirect()` では代用できない。ルート直下の `loading.tsx` により
+       * ストリーミングのシェルが先に送出され、`redirect()` は HTTP ステータスに
+       * 反映されず `<meta http-equiv="refresh">` へ格下げされる（実測済み）。
+       *
+       * 2組目が公開されたらこのエントリを削除すること。`src/app/special/page.tsx`
+       * の一覧表示がそのまま復帰する。
+       */
+      ...(SPECIAL_VISIBLE
+        ? [
+            {
+              source: "/special",
+              destination: SPECIAL_LANDING_PATH,
+              statusCode: 302 as const,
+            },
+          ]
+        : []),
     ];
   },
   images: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from "next";
 import { getEventsList, getSpecialEvents } from "@/lib/events";
 import { getNewsList } from "@/lib/news";
-import { siteConfig } from "@/data/site";
+import { siteConfig, SPECIAL_VISIBLE } from "@/data/site";
 
 /**
  * サイトマップ自動生成
@@ -140,5 +140,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error("Failed to fetch news for sitemap:", error);
   }
 
-  return [...staticPages, ...eventPages, ...specialPages, ...newsPages];
+  // SPECIAL_VISIBLE が true の間、/special は LP へ302転送される
+  // （next.config.ts の redirects()）。転送元をサイトマップに載せると
+  // Search Console が「リダイレクトあり」として除外するため、その間は落とす。
+  // 転送エントリを外して一覧へ戻したときは、この判定も併せて見直すこと。
+  const canonicalStaticPages = SPECIAL_VISIBLE
+    ? staticPages.filter((page) => page.url !== `${baseUrl}/special`)
+    : staticPages;
+
+  return [...canonicalStaticPages, ...eventPages, ...specialPages, ...newsPages];
 }

--- a/src/app/special/[id]/page.tsx
+++ b/src/app/special/[id]/page.tsx
@@ -166,9 +166,11 @@ export default async function SpecialDetailPage({ params }: SpecialPageProps) {
                 </li>
                 <li aria-hidden="true">/</li>
                 <li>
-                  <Link href="/special" className="hover:text-gray-900 hover:underline">
-                    著名人企画
-                  </Link>
+                  {/*
+                    リンクにしない。公開が1組の間は /special がこの LP へ転送されるため、
+                    リンクにすると現在地の親が自分自身になる。
+                  */}
+                  <span>著名人企画</span>
                 </li>
                 <li aria-hidden="true">/</li>
                 <li aria-current="page" className="text-gray-900">

--- a/src/app/special/page.tsx
+++ b/src/app/special/page.tsx
@@ -37,6 +37,17 @@ export const revalidate = 3600;
  * 行き止まりにしないためのページでもあります。
  *
  * SPECIAL_VISIBLE が false の間は準備中表示（EVENTS_VISIBLE とは独立）。
+ *
+ * IMPORTANT: 公開中の著名人企画が1組だけの現在、`/special` は `next.config.ts` の
+ * `redirects()` で LP へ 302 されるため、このページは SPECIAL_VISIBLE が false の
+ * ときの準備中表示にしか到達しません。ここでの `redirect()` 呼び出しでは代用
+ * できないことが確認済みです。ルート直下の `loading.tsx` によりストリーミングの
+ * シェルが先に送出され、ページのレンダリング中に投げた `redirect()` は HTTP
+ * ステータスに反映されず `<meta http-equiv="refresh">` へ格下げされます
+ * （HTTP 200 のまま1秒待たされる）。転送はルート照合より前の層で行うこと。
+ *
+ * 2組目が公開されたら `next.config.ts` の `/special` エントリを削除すれば、
+ * このページが一覧として復帰します。
  */
 export default async function SpecialPage() {
   if (!SPECIAL_VISIBLE) {


### PR DESCRIPTION
## 概要

著名人企画（MON7A）の告知導線を整理し、次の2本のリダイレクトを追加する。

| リクエスト | ステータス | 転送先 |
| --- | --- | --- |
| `/97th/about`（末尾スラッシュ付きも） | **302** | `/special/special-event-mon7a` |
| `/special`（末尾スラッシュ付きも） | **302** | `/special/special-event-mon7a` |

いずれも**1ホップ**で着地する。

## なぜ `next.config.ts` なのか

### 1. `/97th/about` は放置すると404ではなく200を返していた

`src/app/[locale]/about/page.tsx` の `[locale]` が `97th` をロケールとして飲み込み、`/about` と同じ内容を200で重複配信していた（本番実測）。`/foo/about` や `/hoge/access` でも同じことが起きる。`redirects()` は動的ルートの照合より先に走るため、ここで塞ぐのが確実。

> `/97th` 以外の未知セグメントは未対応のまま。#128 で追跡。

### 2. ページ内 `redirect()` では本物の転送にならない

当初は `src/app/special/page.tsx` で「公開が1組のときだけ `redirect()`」を実装したが、返ってきたのは 307 ではなく:

```
HTTP/1.1 200 OK
<meta http-equiv="refresh" content="1;url=/special/special-event-mon7a"/>
```

ルート直下の `src/app/loading.tsx` によりストリーミングのシェルが先に送出され、`redirect()` はもうステータスコードへ反映できないため。`export const dynamic = "force-dynamic"` を足しても同じだった。

**このアプリで本物の転送を返せる層は `next.config.ts` の `redirects()` と `src/proxy.ts` だけである。** 既存の `/events/[id]` も同じ症状にある（#127）。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `next.config.ts` | 302を2本追加。転送先IDは `src/data/special-banner.ts` の `eventId` を出典とし、`NEXT_PUBLIC_SPECIAL_VISIBLE` で分岐 |
| `src/app/special/page.tsx` | コード変更なし。なぜページ内 `redirect()` が使えないかを注記 |
| `src/app/special/[id]/page.tsx` | パンくず「著名人企画」からリンクを外す（`/special` が自分自身へ戻る輪の解消） |
| `src/app/sitemap.ts` | 転送中は `/special` をサイトマップから除外 |
| `.claude/CLAUDE.md` / `docs/dev/domain-migration.md` | 転送一覧・設計判断・既知の制約を記録 |

## 検証（ローカル Production サーバー、`pnpm build && pnpm start`）

```
/97th/about/     -> 302 -> /special/special-event-mon7a (200, ホップ1)
/97th/about      -> 302 -> /special/special-event-mon7a (200, ホップ1)
/special         -> 302 -> /special/special-event-mon7a (200, ホップ1)
/special/        -> 302 -> /special/special-event-mon7a (200, ホップ1)
```

**非公開時に404へ落ちないこと（最重要）** — `NEXT_PUBLIC_SPECIAL_VISIBLE=false` でビルド:

```
/97th/about/  -> 302 -> /special -> 200「準備中です」
/special      -> 200「準備中です」
```

**既存転送の回帰なし**:

```
/sfa          -> 301 -> /about
/96th/about/  -> 301 -> https://96th.setagayafes.org/about
/about /events /timetable /info -> 200
```

**サイトマップ** — `/special` が消え、`/special/special-event-mon7a` のみ残ることを確認。

**パンくず** — `<li><span>著名人企画</span></li>` となりリンクなし。「トップ」のリンクは維持。

`pnpm lint` 0 errors（既存warning 7件は本PRの変更箇所外）／ `pnpm format:check` 通過 ／ `pnpm build` 成功。

## デプロイ時の注意

`NEXT_PUBLIC_SPECIAL_VISIBLE` は**ビルド時に埋め込まれる**。Vercel Production で `true` であることは確認済み。false のままだと `/97th/about` は準備中ページ止まりになる。

## 今後

**2組目の著名人企画が公開されたら `next.config.ts` の `/special` エントリを削除すること。** `src/app/special/page.tsx` の一覧表示がそのまま復帰する。`src/app/sitemap.ts` の除外判定も併せて見直す。

## 関連

- #127 `/events/[id]` の誘導が meta refresh になっている（同一の根本原因、本PRでは未対応）
- #128 未知のロケールセグメントが200で重複配信（`/97th/about` のみ本PRで個別に対処）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK8ibRD4HZp1thFXfQoyL3