### PR TITLE
DOC: 本番反映の確認で公開ドメインをポーリングしない旨を追記

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -113,6 +113,7 @@ docs/
   - 企画・お知らせの公開フラグと非公開時の表示範囲
   - ワークフローでの参照方法（`secrets.` vs `vars.`）
   - ローカル開発（.env.local）との対応表
+  - 本番反映の完了判定（sha 突き合わせ／公開ドメインをポーリングしない）
   - **Vercel の本番反映は挙動が変わった。** 2026-08-27 以降は main へのマージコミットが約1分で自動 Production 化される（それ以前は人手のみ）。**どちらの前提も思い込まず、毎回 Production デプロイの sha と main 先端の一致で判定する。** 一致していても意図した変更が出ているかは公開ドメインの実応答で確認する
   - **`vercel promote` は使わない。** 再ビルドしないため Preview 環境変数の成果物が本番に出る（`MICROCMS_SERVICE_DOMAIN` は環境別）。`vercel redeploy --target production` を使う
   - **`Aliased:` 表示は DNS を保証しない。** 公開ドメインは `curl -sI` の `server` / `location` ヘッダで実応答を確認する。`NEXT_PUBLIC_URL` のホストが名前解決できるかも確認する

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -171,6 +171,8 @@ curl -s <deployment url>/special | grep -o '準備中'   # 何も出なければ
 | `db497f6`      | 2026-08-27 04:59     | 2026-08-27 05:00:16    | 約1分 |
 | `70db2dd`      | 2026-08-29 05:27:37  | 2026-08-29 05:28:23    | 46秒  |
 | `b95ef11`      | 2026-08-29 05:32:49  | 2026-08-29 05:33:42    | 53秒  |
+| `a950d40`      | 2026-08-29 09:35:14  | 2026-08-29 09:36:39    | 85秒  |
+| `5318b52`      | 2026-08-29 09:54:15  | 2026-08-29 09:55:00    | 45秒  |
 
 Production が作られるのは**マージコミットに対してだけ**です。そのマージに含まれる個々のコミット（`3530cd4` など）には Production デプロイは作られません。Vercel はブランチ先端をデプロイするためで、正常な挙動です。
 
@@ -220,6 +222,37 @@ done
 ```
 
 CSS チャンクは複数に分割され、**探している規則は1本にしか入っていません。** 1ファイルだけ見て「無い」と判断すると誤検証になります。
+
+#### 公開ドメインをポーリングしない
+
+> [!CAUTION]
+> **反映を待つつもりで `curl` を連続して叩かないでください。** Vercel の bot 対策が発動し、
+> `x-vercel-mitigated: challenge`（Vercel Security Checkpoint）が **403** で返るようになります。
+> **ヘッドレスブラウザでも JS challenge は通過できません**（`agent-browser` でもページタイトルが
+> `Vercel Security Checkpoint` のまま止まります）。**サイト障害と見分けがつかず、確認手段を失います。**
+
+2026-08-29、40 回ループで `curl https://setagayafes.org/` を叩いて実際に踏みました。
+上表のとおり Production 作成までは **45〜85 秒**です。**1〜2 分待って 1 回だけ**確認してください。
+
+踏んでしまった場合は、Production デプロイの直接 URL を使えば確認できます。
+challenge が掛かるのは独自ドメイン側だけです。
+
+```bash
+DEP=$(gh api "repos/ManatoYamashita/tcu-setagayafes97-web/deployments?environment=Production&per_page=1" --jq '.[0].id')
+URL=$(gh api "repos/ManatoYamashita/tcu-setagayafes97-web/deployments/$DEP/statuses" --jq '.[0].environment_url')
+curl -sL "$URL" | grep -o '<探しているマークアップ>'
+```
+
+独自ドメイン側の challenge も数分で自然に解除されます。
+
+> [!WARNING]
+> **本ファイルの登録状況の表と実例は、いずれも記載時点のスナップショットです。**
+> 「2026-08-17 実測」「実例：…の登録漏れ（2026-08-17）」を**現在の状態と読まないでください。**
+> フラグが今どうなっているかは、公開ドメインの実応答でしか確定しません。
+>
+> ```bash
+> curl -sL https://setagayafes.org/special | grep -c 準備中   # 0 なら公開済み
+> ```
 
 ### `vercel promote` は使わない
 


### PR DESCRIPTION
## 背景

2026-08-29、PR #129 のマージ後に本番反映を確認しようとして `curl https://setagayafes.org/` を40回ループで叩いたところ、Vercel の bot 対策が発動し `x-vercel-mitigated: challenge`（Vercel Security Checkpoint）が **403** で返るようになりました。

**ヘッドレスブラウザでも JS challenge は通過できず**（`agent-browser` でもページタイトルが `Vercel Security Checkpoint` のまま）、一時的に本番の確認手段を失いました。**サイト障害と見分けがつきません。**

## 追記した内容

### 1. 公開ドメインをポーリングしない（`### 完了判定` 節）

- 連続アクセスで challenge が発動すること、ヘッドレスでは通過できないこと
- Production 作成までは実測 45〜85 秒。**1〜2分待って1回だけ**確認する
- 踏んだ場合の回避策：Production デプロイの直接 URL を使う（challenge は独自ドメイン側にしか掛からない）

### 2. マージ→Production の実測表に2件追加

| マージコミット | main への時刻 | Production 作成 | 差 |
| --- | --- | --- | --- |
| `a950d40` | 09:35:14 | 09:36:39 | 85秒 |
| `5318b52` | 09:54:15 | 09:55:00 | 45秒 |

### 3. 記載時点のスナップショットである旨の明示

登録状況の表（「2026-08-17 実測」）と「実例：`NEXT_PUBLIC_SPECIAL_VISIBLE` の登録漏れ（2026-08-17）」を**現在の状態と読み違える事故**が実際に起きました。同フラグは既に Vercel Production で有効なのに、この記述を根拠に「マージしても本番には出ない」と繰り返し誤った報告をしています。

フラグの現在値は公開ドメインの実応答でしか確定しない旨を追記しました。

## 検証

- `prettier --check` 通過
- `docs/INDEX.md` の ci-env.md の項目に「本番反映の完了判定」を追加（`AGENTS.md` のドキュメント運用ルールに従い索引を改訂）
- 隔離した git worktree で作業しており、メインの作業ツリーには触れていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Co3nHCVFUGDwDpo6Tz1Nem
