### PR TITLE
FIX: 未知のロケールセグメントが200で重複配信される問題を塞ぐ

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -283,13 +283,19 @@ push 時は head をそのまま、PR 時は head を base へマージした結
 > ページ内 `redirect()` のままであり、上記のとおり 200 + meta refresh になっている。
 > 未解消（要Issue）。
 
-### 未知のロケールセグメントが 200 を返す問題（未解消）
+### 未知のロケールセグメントの扱い
 
-`src/app/[locale]/` の `[locale]` は任意の文字列にマッチするため、
+`src/app/[locale]/` の `[locale]` は任意の文字列にマッチするため、放置すると
 `/foo/about` や `/hoge/access` が 404 ではなく `/about`・`/access` と同じ内容を
-200 で返している。`src/app/[locale]/layout.tsx` の `notFound()` はストリーミングの
+200 で返す。`src/app/[locale]/layout.tsx` の `notFound()` はストリーミングの
 シェル送出後に投げられるためステータスに反映されない。
-`/97th/about` だけは `next.config.ts` の 302 で個別に塞いだが、根本解決は未着手（要Issue）。
+
+`src/app/[locale]/layout.tsx` の `export const dynamicParams = false;` で解決済み
+（#128）。`generateStaticParams` が返す4ロケール以外は、レンダリングより前の
+ルート照合で 404 になる。**この宣言を外すと重複配信が再発する。**
+
+なお `/en` `/zh` `/ko` 単体のURLは別問題（多言語トップページが無い）で、
+引き続き 404 のまま。#35 で追跡。
 
 ## 主要機能
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -12,6 +12,23 @@ export function generateStaticParams() {
 }
 
 /**
+ * `generateStaticParams` が返さないロケールを Next.js のルーティング層で404にする。
+ *
+ * IMPORTANT: 下の `notFound()` だけでは 404 にならない。ルート直下の
+ * `src/app/loading.tsx` によりストリーミングのシェルが先に送出されるため、
+ * レンダリング中に投げた `notFound()` は HTTP ステータスへ反映されず、
+ * 404の本文が 200 のまま返る。その結果 `/foo/about` や `/97th/access` が
+ * `/about`・`/access` と同じ内容を200で重複配信していた。
+ *
+ * `dynamicParams` はレンダリングより前のルート照合で評価されるため、この影響を
+ * 受けない。下の `notFound()` は型の絞り込みと将来の防御として残す。
+ *
+ * ロケールを増やすときは `src/i18n/routing.ts` の `locales` を更新すること。
+ * `generateStaticParams` はそこから生成しているため、追随は自動で効く。
+ */
+export const dynamicParams = false;
+
+/**
  * ロケール対応レイアウト
  *
  * - 多言語対応ページ専用のレイアウト


### PR DESCRIPTION
Closes #128

## 問題

`src/app/[locale]/` の `[locale]` が任意の文字列にマッチするため、**存在しないロケールを含む2セグメントURLが 404 ではなく 200 を返し、日本語ページと同じ内容を配信していた。**

```
https://setagayafes.org/foo/about     -> 200  <title>委員会について | 東京都市大学 第97回 世田谷祭</title>
https://setagayafes.org/97th/access   -> 200
https://setagayafes.org/bar/info/faq  -> 200
```

`x-nextjs-prerender: 1` / `x-vercel-cache: HIT` が付いており、CDNにキャッシュされたうえで配信されていた。無限に近い数の重複URLが成立するため、外部から適当なリンクを張られるだけでインデックスされうる。誤ったロケールで `NextIntlClientProvider` が初期化され `<div lang="foo">` が出力される、というアクセシビリティ上の問題も伴う。

## なぜ既存の `notFound()` で止まらないのか

`src/app/[locale]/layout.tsx` にはロケール検証が入っている。

```ts
if (!routing.locales.includes(locale as Locale)) {
  notFound();
}
```

しかしルート直下の `src/app/loading.tsx` によりストリーミングのシェルが先に送出されるため、**レンダリング中に投げた `notFound()` は HTTP ステータスへ反映されない**。404の本文が 200 のまま返る。

これは #127 と同じ根本原因である（あちらは `redirect()` が `<meta http-equiv="refresh">` へ格下げされる）。

## 修正

`dynamicParams` は**レンダリングより前のルート照合で評価される**ため、この影響を受けない。

```ts
export function generateStaticParams() {
  return routing.locales.map((locale) => ({ locale }));
}

export const dynamicParams = false;
```

既存の `notFound()` は型の絞り込みと将来の防御として残す。ロケールを増やすときは `src/i18n/routing.ts` の `locales` を更新すれば `generateStaticParams` 経由で自動追随する。

## 検証（ローカル Production サーバー、`pnpm build && pnpm start`）

**塞ぐべきURL — すべて 404 になった（変更前はすべて 200）**

```
/foo/about  /97th/access  /bar/info/faq  /baz/about/privacy
/xx/access  /yy/info/contact  /zz/info/guide
```

404は本物。`content-type: text/html`、本文は既存の `/foo/bar` の404ページと**バイト単位で同一**。ソフト404ではない。存在しないロケールへの `hreflang` の `Link:` ヘッダも出ていない（`src/proxy.ts` のコメントが警告していた問題は発生せず）。

**壊してはいけないURL — すべて 200 のまま**

```
/about  /about/privacy  /access  /info/guide  /info/faq  /info/contact
/en/about  /en/access  /en/info/faq  /zh/about  /zh/access  /ko/about  /ko/info/contact
```

**非多言語ルート — 影響なし**

```
/  /events  /timetable  /info  /info/pamphlet  /about/sponsors
/special/special-event-mon7a  /robots.txt  /sitemap.xml   すべて 200
```

**転送系 — 回帰なし**

```
/ja/about -> 307 -> /about          /ja/events -> 307 -> /events
/97th/about -> 302 -> /special/special-event-mon7a
/special -> 302 -> /special/special-event-mon7a
/sfa -> 301 -> /about               /96th/about/ -> 301 -> 96th.setagayafes.org/about
```

`pnpm lint` 0 errors（既存warning 7件は本PRの変更箇所外）／ `pnpm format:check` 通過 ／ `pnpm build` 成功。ISR設定や多言語ページのプリレンダにも変化なし。

## スコープ外

- **#35**（`/en` `/zh` `/ko` 単体のURLが404）は本PRでは解決しない。多言語トップページが存在しないという別問題であり、変更前後とも404のまま
- **#127**（`/events/[id]` の誘導が meta refresh）は根本原因が同じだが、`dynamicParams` では解決しない。`redirects()` へのビルド時展開か `src/proxy.ts` での処理が要る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK8ibRD4HZp1thFXfQoyL3