### PR TITLE
FEATURE: ヒーローのモバイルCTAに著名人企画への導線を追加

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -271,14 +271,30 @@ export function HeroSection({ latestNews }: HeroSectionProps) {
         <p className="text-xs md:text-sm tracking-[0.2em] text-primary-400/70 mt-2 md:mt-3">
           {siteConfig.openTime} - {siteConfig.closeTime}
         </p>
-        {/* モバイル用CTA（md以上では非表示） */}
-        <Link
-          href="/events"
-          prefetch={false}
-          className="inline-block bg-primary-600 text-white text-sm font-medium px-6 py-3 rounded-full hover:bg-primary-700 transition-colors mt-4 md:hidden"
-        >
-          企画を探す
-        </Link>
+        {/*
+          モバイル用CTA（md以上では非表示）
+
+          著名人企画は SPECIAL_VISIBLE で判定しない。未解禁でも /special は準備中ページ
+          として成立し、「今年も著名人企画がある」ことを伏せる必要はないため
+          （出演者名は出ない）。ヘッダーナビも同じ方針で常時表示している。
+          詳細は src/data/navigation.ts のコメントを参照。
+        */}
+        <div className="flex flex-wrap items-center gap-3 mt-4 md:hidden">
+          <Link
+            href="/events"
+            prefetch={false}
+            className="inline-block bg-primary-600 text-white text-sm font-medium px-6 py-3 rounded-full hover:bg-primary-700 transition-colors"
+          >
+            企画を探す
+          </Link>
+          <Link
+            href="/special"
+            prefetch={false}
+            className="inline-block bg-white/80 text-primary-700 border border-primary-600 text-sm font-medium px-6 py-3 rounded-full hover:bg-white transition-colors"
+          >
+            著名人企画
+          </Link>
+        </div>
       </div>
 
       {/* [z-30] 右下 最新ニュース（デスクトップのみ） */}


### PR DESCRIPTION
## 概要

トップページのヒーロー（モバイル表示）にある「企画を探す」ボタンの横に、著名人企画（`/special`）への導線を追加した。ページフィードバックでの依頼に対応するもの。

```jsx
<div className="flex flex-wrap items-center gap-3 mt-4 md:hidden">
  <Link href="/events">企画を探す</Link>    {/* 塗り: primary-600 */}
  <Link href="/special">著名人企画</Link>   {/* 枠線: 白背景 + primary-600 枠 */}
</div>
```

変更は `src/components/home/HeroSection.tsx` のみ（+24 / -8）。

## 設計判断

### `SPECIAL_VISIBLE` で出し分けていない

未解禁でも `/special` は準備中ページとして成立し、「今年も著名人企画がある」ことを伏せる必要はない（出演者名は出ない）。ヘッダーナビも同じ方針で常時表示しており、`src/data/navigation.ts` にその理由が記録されている。ここだけフラグで消すと両者の挙動が食い違う。

### `SpecialGuestSection` との併存について

`page.tsx` では Hero の直下に `SpecialGuestSection` が置かれているが、以下の理由で重複とは考えていない。

| | ヒーロー内 CTA（本PR） | `SpecialGuestSection` |
| --- | --- | --- |
| 表示位置 | ファーストビュー（スクロール不要） | Hero が `100svh` のため、スクロール後 |
| `SPECIAL_VISIBLE=false` 時 | 表示される（唯一の導線として残る） | `return null` でセクションごと消える |

未解禁の間はこの CTA だけが著名人企画への導線になる。

### 視覚的な主従

既存の「企画を探す」を塗り、著名人企画を枠線にして階層をつけた。ボタン2つと `gap-3` で約248px。最小端末 320px から親の `px-6`（48px）を引いた 272px に収まる。念のため `flex-wrap` も付けている。

## 検証

- SSR HTML に両ボタンが正しいクラスで出力されることを確認
- `flex-wrap` / `gap-3` / `bg-white/80` / `border-primary-600` / `text-primary-700` がすべて本番CSSに出力されることを確認
- `pnpm lint`（0 errors）/ `pnpm format:check` / `npx tsc --noEmit` 通過

### 未実施

**実機での目視確認ができていない。** 検証環境で Spotlight の再インデックスによりロードアベレージが 13〜24 に達し、ハイドレーションに50秒以上かかる状態で、スクリーンショットにヒーロー要素が現れなかったため。レビュー時に実機でご確認いただきたい。

## 補足（本PRの対象外）

`.env.local` で `NEXT_PUBLIC_SPECIAL_VISIBLE` が2度定義されており（L13 `false` / L16 `true`）、後勝ちで `true` になっている。解禁日が契約で決まる著名人企画のフラグとしては事故のもとなので、意図した状態か確認をおすすめする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJ5YWsRDZQgzot8fuL1UwV