### PR TITLE
FIX: 企画準備中でも著名人企画セクションを /events に表示する

### DIFF
--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -97,12 +97,12 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 
 **この2つは独立している。** 著名人の発表はチケット販売と紐づき、一般企画一覧の公開より先行することがあるため、別のフラグに分けている。
 
-| `EVENTS_VISIBLE` | `SPECIAL_VISIBLE` | 挙動                                                              |
-| ---------------- | ----------------- | ----------------------------------------------------------------- |
-| `false`          | `false`           | すべて準備中                                                      |
-| `false`          | **`true`**        | **`/special` のみ公開。`/events` `/timetable` は準備中**          |
-| `true`           | `false`           | `/events` `/timetable` は公開。**ただし `type = special` は除外** |
-| `true`           | `true`            | すべて公開                                                        |
+| `EVENTS_VISIBLE` | `SPECIAL_VISIBLE` | 挙動                                                                                           |
+| ---------------- | ----------------- | ---------------------------------------------------------------------------------------------- |
+| `false`          | `false`           | すべて準備中                                                                                   |
+| `false`          | **`true`**        | **`/special` と `/events` の著名人セクションを公開。`/events` の一覧と `/timetable` は準備中** |
+| `true`           | `false`           | `/events` `/timetable` は公開。**ただし `type = special` は除外**                              |
+| `true`           | `true`            | すべて公開                                                                                     |
 
 > [!WARNING]
 > **著名人ページを先行公開するときは `getSpecialEvents()` / `getSpecialEventById()` を使うこと。**

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -35,9 +35,25 @@ export const revalidate = 3600;
 /**
  * 企画一覧ページ
  * SSG + クライアントサイドフィルタリング
- * EVENTS_VISIBLE が false の間は準備中表示
+ * EVENTS_VISIBLE が false の間は準備中表示（著名人企画のセクションは下記のとおり残す）
  */
 export default async function EventsPage() {
+  /*
+   * 著名人企画は EVENTS_VISIBLE ではなく SPECIAL_VISIBLE だけで解禁する。
+   * 企画一覧が準備中でも、解禁済みの著名人企画には /events から到達できなければならない。
+   * データ層（getSpecialEventById）も同じ理由で EVENTS_VISIBLE に依存しないため、
+   * ここで組み立てておけば準備中・公開中のどちらの分岐でもそのまま置ける。
+   *
+   * ラッパーの余白だけが残らないよう、SPECIAL_VISIBLE で括ってから組み立てる
+   * （SpecialGuestSection 自身も false なら null を返すが、それでは div が残る）。
+   * 左右端は ComingSoon / EventsContent のルート（container mx-auto px-4）に合わせる。
+   */
+  const specialGuestSection = SPECIAL_VISIBLE ? (
+    <div className="container mx-auto px-4 pb-12">
+      <SpecialGuestSection variant="sheet" />
+    </div>
+  ) : null;
+
   if (!EVENTS_VISIBLE) {
     return (
       <PageSheetLayout hero={pageHeroes.events}>
@@ -45,6 +61,9 @@ export default async function EventsPage() {
           title="企画情報は準備中です"
           description="第97回 世田谷祭の企画情報は現在準備中です。公開までもうしばらくお待ちください。"
         />
+        {/* 準備中でも著名人企画だけは出す。上部の細いリンクは、ここでは一覧を挟まず
+            すぐ下にこのセクションが来るため重複になるので付けない */}
+        {specialGuestSection}
       </PageSheetLayout>
     );
   }
@@ -81,14 +100,8 @@ export default async function EventsPage() {
       {/* 企画一覧コンテンツ */}
       <EventsContent initialEvents={events} />
 
-      {/* 一覧を見終えた来場者をもう一度 LP へ送る。上部の細いリンクとは粒度が違うので併存させる。
-          左右端は EventsContent のルート（container mx-auto px-4）に合わせる。
-          ラッパーの余白だけが残らないよう、上のリンクと同じ SPECIAL_VISIBLE で括る */}
-      {SPECIAL_VISIBLE && (
-        <div className="container mx-auto px-4 pb-12">
-          <SpecialGuestSection variant="sheet" />
-        </div>
-      )}
+      {/* 一覧を見終えた来場者をもう一度 LP へ送る。上部の細いリンクとは粒度が違うので併存させる */}
+      {specialGuestSection}
     </PageSheetLayout>
   );
 }

--- a/src/components/special/SpecialGuestSection.tsx
+++ b/src/components/special/SpecialGuestSection.tsx
@@ -17,8 +17,8 @@ import { SpecialGuestMotion } from "./SpecialGuestMotion";
  * SPECIAL_VISIBLE が false の間はセクションごと非表示にします。著名人は解禁日が
  * 契約で決まっており、URL の先行露出が事故になるためです（src/data/site.ts のコメント参照）。
  * EVENTS_VISIBLE には依存しないため、著名人だけを先行公開する運用でも表示されます。
- * ただし /events 自体が EVENTS_VISIBLE=false のとき準備中表示で終わるため、
- * そちらのカードが出るのは両方が true のときだけです。
+ * /events は EVENTS_VISIBLE=false のとき一覧が準備中表示になりますが、その場合も
+ * このセクションだけは準備中カードの下に残します（src/app/events/page.tsx）。
  *
  * 文言は microCMS ではなく src/data/special-banner.ts が持ちますが、リンク先が実在するか
  * どうかだけは getSpecialEventById() で確認します。ID が変わって LP に到達できない場合は、

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -99,7 +99,7 @@ export const NEWS_VISIBLE: boolean = process.env.NEXT_PUBLIC_NEWS_VISIBLE === "t
  * | EVENTS_VISIBLE | SPECIAL_VISIBLE | 挙動                                          |
  * | -------------- | --------------- | --------------------------------------------- |
  * | false          | false           | すべて準備中                                  |
- * | false          | true            | /special のみ公開。/events・/timetable は準備中 |
+ * | false          | true            | /special と /events の著名人セクションを公開。/events の一覧・/timetable は準備中 |
  * | true           | false           | /events・/timetable は公開。type=special は除外 |
  * | true           | true            | すべて公開                                    |
  *


### PR DESCRIPTION
## 背景

`/events` は `EVENTS_VISIBLE=false` の間、`src/app/events/page.tsx` の early return で `ComingSoon` だけを返して終わっていた。この early return が `SPECIAL_VISIBLE` の分岐より **前** にあるため、著名人企画が解禁済み（`SPECIAL_VISIBLE=true`）でも `/events` からは上部リンク・最下部セクションのどちらにも到達できなかった。

`SPECIAL_VISIBLE` は `EVENTS_VISIBLE` と独立したフラグで、著名人だけを先行公開する運用が前提である（`src/data/site.ts` の組み合わせ表）。データ層の `getSpecialEventById()` も `EVENTS_VISIBLE` に依存しない造りになっており、詰まっていたのはページ側だけだった。

現在の本番はまさに `EVENTS_VISIBLE=false` / `SPECIAL_VISIBLE=true` の組み合わせである。

## 変更内容

- `src/app/events/page.tsx`
  - 著名人企画セクションを `specialGuestSection` 変数へ切り出し、準備中・公開中の両分岐で使う
  - 準備中時は `ComingSoon` の **下** に配置。上部の細いリンクは、一覧を挟まずすぐ下にセクションが来て重複になるため出さない
- `src/components/special/SpecialGuestSection.tsx` — 「/events のカードが出るのは両フラグ true のときだけ」という説明コメントを実態に合わせて修正
- `src/data/site.ts` / `docs/dev/ci-env.md` — フラグ組み合わせ表の `false` × `true` の行を更新

`/timetable` は今回対象外（ステージの時間割が主題で、著名人1組のバナーを置く必然性が薄いため）。

## 確認

- `pnpm lint` — 0 errors（警告7件はいずれも既存・無関係）
- `pnpm format:check` — pass
- `pnpm build` — 成功
- プリレンダ結果 `.next/server/app/events.html` に `deferred-section--special` と `href="/special/special-event-mon7a"` が出力されること、上部の細いリンク（`href="/special"`）は出ないことを確認
- ローカル（`EVENTS_VISIBLE=false` / `SPECIAL_VISIBLE=true`）でブラウザ表示を確認。準備中カード → 区切り線 → 著名人企画（ロゴ・チケット明細・画像・CTA）の順で描画され、入場モーションも動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017u4zxBZw3APWJhhTmLSnWT