### PR TITLE
FIX: 効果のないコンポーネント側 revalidate 宣言を削除する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,5 +46,11 @@ export default async function Home() {
   );
 }
 
-// ISR設定: 1時間ごとに再検証
+/**
+ * ISR設定: 1時間ごとに再検証。
+ *
+ * Route Segment Config が有効なのは page / layout / route の3種のみである。
+ * このページが描画するコンポーネント側に `export const revalidate` を書いても
+ * Next.js は読み取らないため、配下のデータ取得はすべてこの値で再検証される。
+ */
 export const revalidate = 3600;

--- a/src/components/home/FeaturedEvents.tsx
+++ b/src/components/home/FeaturedEvents.tsx
@@ -59,5 +59,3 @@ export async function FeaturedEvents() {
     </section>
   );
 }
-
-export const revalidate = 3600;

--- a/src/components/home/SponsorBanner.tsx
+++ b/src/components/home/SponsorBanner.tsx
@@ -21,6 +21,3 @@ export async function SponsorBanner() {
     </section>
   );
 }
-
-// ISR設定: 24時間ごとに再検証
-export const revalidate = 86400;


### PR DESCRIPTION
## 概要

Route Segment Config（`export const revalidate`）が有効なのは `page` / `layout` / `route` の3種のみである。それ以外のコンポーネントファイルに書いても Next.js は読み取らない。

本リポジトリには、一度も機能していない宣言が2箇所あった。

| ファイル | 宣言 | 実際の挙動 |
| --- | --- | --- |
| `src/components/home/FeaturedEvents.tsx` | `revalidate = 3600` | 無視される |
| `src/components/home/SponsorBanner.tsx` | `revalidate = 86400` | 無視される（実際は `page.tsx` の 3600） |

## なぜ「無害な残骸」ではないか

`SponsorBanner` の `86400` は「協賛バナーは24時間キャッシュ」と読める。しかし実際は `src/app/page.tsx` の `revalidate = 3600` に飲み込まれ、1時間で再検証されている。**実挙動と食い違う記述**であり、読んだ者を誤らせる。

## 実測による裏付け（2026-08-30）

```
$ curl -sI https://setagayafes.org/ | grep -iE '^(age|x-vercel-cache)'
age: 4104
x-vercel-cache: STALE
```

`age` が 4104 秒（約68分）の時点で `STALE` 判定になっている。仮に `86400`（24時間）が効いていれば、この時点では `HIT` のままのはずである。トップページが `page.tsx` の 3600 で再検証されていることの直接的な証拠。

## 変更内容

- 上記2ファイルの無効な `export const revalidate` を削除
- `src/app/page.tsx` のコメントを拡充し、配下コンポーネントに書いても無効である旨を明記（再発防止）

## 検証

- `pnpm lint` — error 0（既存 warning 7件のみ、本変更とは無関係）
- `pnpm format:check` — pass
- `npx tsc --noEmit` — pass

削除対象は実行時に評価されないモジュールスコープの定数であり、レンダリング結果・キャッシュ挙動はいずれも変化しない。

## 関連

microCMS 更新の反映が最大1時間遅れる件は、オンデマンド再検証の実装で別途対応する（Issue を後続で起票）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134JQ8xLW5SURuscR5RZPxh