### PR TITLE
DOC: 白いシート上のカード枠の指針を Agent Prompt Guide へ追記

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -392,10 +392,24 @@ Line Height:  1.75
 - 本文フォント: Noto Sans JP, sans-serif
 - 見出しフォント: Kaisei Opti, serif（30px以上のみ）
 - 行間: 本文は line-height: 1.75
-- カード背景: bg-white/10, rounded-2xl
-- ボーダー: border-gray-200/20
+- カード背景: 淡紫背景のページは bg-white/10, rounded-2xl / 白いシート上は bg-white
+- ボーダー: 淡紫背景のページは border-gray-200/20 / 白いシート上は border-gray-200
 - テキスト色: text-gray-900（実配信 #070707）
 ```
+
+> [!IMPORTANT]
+> **`bg-white/10` と `border-gray-200/20` は淡紫のページ背景（`bg-secondary`）を前提にした値である。**
+> `PageSheetLayout` の白いシート（`bg-white`）の上では、`bg-white/10` は純白になって下地と分離せず、
+> `border-gray-200/20` は白地に対して **1.08:1** となって消える。
+>
+> 白いシート上のカードは不透明な `border-gray-200`（1.53:1）を使い、境界の識別は
+> `border-l-4 border-l-primary-600`（7.45:1）のアクセントラインで担保する。
+> ホバーで枠色を変えるときは、`hover:border-*`（詳細度 0,2,0）が非ホバーの
+> `border-l-*`（0,1,0）に詳細度で勝って左辺まで塗り替えるため、`hover:border-l-*` も明示すること。
+>
+> 実装例は `src/components/timetable/TimetableEventCard.tsx`。どのページが白いシートかは
+> `PageSheetLayout` の利用箇所で判断する。既存コンポーネントの取りこぼしは #144 で追跡している。
+> 比率の根拠は `docs/frontend/design.md`「コントラスト比」（すべて実配信値）。
 
 ---
 
@@ -629,4 +643,4 @@ border-gray-200/20               → 薄いボーダー
 
 ---
 
-**最終更新日**: 2026-04-11
+**最終更新日**: 2026-08-30

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -167,9 +167,13 @@ docs/
 >   IntersectionObserver で遅延取得する際の `rootMargin` の向き
 > - `.claude/CLAUDE.md` デザイン仕様 — トップの `.hero-about-bg` グラデーションの
 >   停止位置を `%` へ戻してはいけない理由（実測値つき）
+> - `DESIGN.md` §9 — `bg-white/10` と `border-gray-200/20` は淡紫背景専用で、
+>   `PageSheetLayout` の白いシート上では消える（1.08:1）。白いシート上のカード枠と
+>   ホバー時の `hover:border-l-*` 明示ルール
 
 - **[design.md](./frontend/design.md)** - デザインシステム（カラー・タイポグラフィトークン）
-  - ブランドカラー `#CD79EE` の HLC 定義（H319 / L64 / C70）と oklch CSS 実装
+  - ブランドカラーの HLC 定義（H319 / L64 / C70）と oklch CSS 実装。仕様 HEX `#CD79EE` に対し
+    実配信は `#bf73e3`（コントラスト検証は必ず実配信値で行う）
   - Primary スケール・Neutral スケール・Semantic カラートークン
   - アクセシビリティ（コントラスト比）ガイドライン
   - Kaisei Opti ブランドフォント仕様と使用制限
@@ -261,4 +265,4 @@ docs/
 
 ---
 
-**最終更新日**: 2026-08-29
+**最終更新日**: 2026-08-30


### PR DESCRIPTION
## 概要

`DESIGN.md` §9 Agent Prompt Guide のプロンプト例が、**白いシート上で枠が消える組み合わせを無条件で推奨していた**ので、背景別に分けて但し書きを足した。ドキュメントのみの変更で、配信されるCSSも画面も変わらない。

## 1. 同一リポジトリ内の2文書が食い違っていた

#145 で `docs/frontend/design.md` に次を新設した。

> 同じ理屈で `border-gray-200/20` は白いシート上で 1.08:1 となり消える。

一方 `DESIGN.md` §9 のプロンプト例は、そのままだった。

```
- カード背景: bg-white/10, rounded-2xl
- ボーダー: border-gray-200/20
```

このテンプレートは **AIエージェントに渡す前提**（`DESIGN.md` 冒頭に明記）なので、放置すると #145 で直したばかりの不具合をそのまま再生産させることになる。

```diff
- - カード背景: bg-white/10, rounded-2xl
- - ボーダー: border-gray-200/20
+ - カード背景: 淡紫背景のページは bg-white/10, rounded-2xl / 白いシート上は bg-white
+ - ボーダー: 淡紫背景のページは border-gray-200/20 / 白いシート上は border-gray-200
```

加えて `> [!IMPORTANT]` で根拠と対処を補足した。

| 白いシート上 | クラス | コントラスト |
| --- | --- | --- |
| 枠線（従来） | `border-gray-200/20` | 1.08:1 — 消える |
| 枠線（推奨） | `border-gray-200` | 1.53:1 |
| アクセント（推奨） | `border-l-4 border-l-primary-600` | 7.45:1 |

ホバー時は `hover:border-*`（詳細度 0,2,0）が非ホバーの `border-l-*`（0,1,0）に勝って左辺まで塗り替えるため、`hover:border-l-*` を明示する旨も書いた。

## 2. `docs/INDEX.md` の更新

- `DESIGN.md` 参照ノートへ §9 を追加（AGENTS.md「更新時は必ず索引を改訂」に対応）
- `design.md` の説明にあった「ブランドカラー `#CD79EE`」を、**仕様値 `#CD79EE` と実配信値 `#bf73e3` の区別が分かる書き方**へ修正。索引だけ読んだ人が仕様HEXでコントラストを計算してしまうのを防ぐ
- 最終更新日 2026-08-29 → 2026-08-30。`DESIGN.md` 側は 2026-04-11 のまま放置されていたので併せて更新

## 検証

- `prettier --check DESIGN.md docs/INDEX.md` 通過
- 表中の比率はすべて出力CSSの実配信値（`#d1d1d1` / `#7b359a` / `#ffffff`）で再計算し、#145 の記載と一致することを確認
- 詳細度の主張は `@tailwindcss/postcss` 4.1.18 に該当クラス列を通した出力で実測

## 積み残し

`DESIGN.md` には `bg-white/10` / `border-gray-200/20` の記述が他に3箇所ある（L229 Card variants 表、L304-307 クラス表、L626-629 ガラスモーフィズムパターン）。いずれも「その指定が何をするか」の**記述**であって新規実装への**指示**ではないため、今回は触っていない。コンポーネント側の取りこぼしは #144 で追跡中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017u4zxBZw3APWJhhTmLSnWT
