### PR TITLE
FEATURE: microCMS Webhook でオンデマンド再検証を受け付ける

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -181,6 +181,34 @@ push 時は head をそのまま、PR 時は head を base へマージした結
   - `select` の値は `day1 : 10月31日（土）` のように **`値 : ラベル`** 形式。コード側は `split(":")` で先頭を取り出す
 - **Informations API**: `category` (sponsor/faq/other), `title`, `description`, `image`, `url`, `priority`
 
+### データ反映の仕組み（オンデマンド再検証）
+
+microCMS の入稿は **Webhook 経由で数秒以内**に本番へ反映される。詳細と運用手順は
+[`docs/dev/content-revalidation.md`](../docs/dev/content-revalidation.md) を参照。
+
+| 系統 | 手段                                                                  | 反映まで               |
+| ---- | --------------------------------------------------------------------- | ---------------------- |
+| 主系 | microCMS Webhook → `POST /api/revalidate` → `revalidatePath()`        | 数秒                   |
+| 保険 | 各ページの `export const revalidate`（3600 / `/special/[id]` は 600） | 最大1時間＋1リクエスト |
+
+**microCMS の Webhook は失敗しても再送されない。** 時間ベース ISR はその取りこぼしを拾う保険であり、
+`revalidate` 宣言を消してはいけない。
+
+> [!IMPORTANT]
+> **microCMS を読むページを増やしたら、[`src/lib/revalidate-targets.ts`](../src/lib/revalidate-targets.ts)
+> の対応表も同じコミットで更新すること。** 漏れてもエラーにはならず、そのページだけ静かに古いまま残る。
+> ページ本体の import だけでなく、**そのページが描画する Server Component が読むデータも数える**
+> （`/` の `SponsorBanner` や `FeaturedEvents` がその例）。
+
+`revalidatePath` はパスの API ではなく**タグの API** である。次の3つはエラーにならず静かに no-op になる。
+
+- `revalidatePath("/about")` — 実体は `/ja/about`。`["/[locale]/about", "page"]` と書く
+- `revalidatePath("/events/[id]")` — 動的ルートには `type` が要る
+- `revalidatePath("/sitemap.xml", "page")` — メタデータルートの派生タグは `/route`。`type` を付けない
+
+**公開フラグ `NEXT_PUBLIC_*_VISIBLE` はビルド時評価であり、Webhook では切り替わらない。**
+解禁作業には従来どおり再デプロイが要る。
+
 ### パフォーマンス最適化
 
 **Vercel Free Plan 制約を考慮:**

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,23 @@ MICROCMS_SERVICE_DOMAIN=example
 MICROCMS_API_KEY=your-api-key
 
 # --------------------------------------------------------------
+# microCMS Webhook（/api/revalidate・オンデマンド再検証）
+# --------------------------------------------------------------
+# microCMS の「カスタム通知」Webhook に入力するシークレットと同じ値を設定する
+# 署名（x-microcms-signature / HMAC-SHA256）の検証に使う
+# 生成: openssl rand -hex 32
+#
+# 未設定のとき /api/revalidate は 500 を返し、すべてのリクエストを拒否する（fail closed）
+# キャッシュ破棄という副作用を持つため、検証できない状態では素通しさせない
+#
+# IMPORTANT: Vercel（Production / Preview）への登録を、microCMS 側で Webhook を作成する
+# 「前に」済ませること。順序を逆にすると最初の数回の入稿が 500 で静かに失われる
+# （microCMS の Webhook は失敗しても再送されない）
+#
+# ビルド時には読まないため、GitHub Actions の Secrets には登録しない（docs/dev/ci-env.md）
+MICROCMS_WEBHOOK_SECRET=
+
+# --------------------------------------------------------------
 # コンテンツ公開フラグ（src/data/site.ts で参照）
 # --------------------------------------------------------------
 # "true" のときのみ公開。未設定・それ以外の値はすべて非公開（安全側デフォルト）

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,8 @@ docs/
 │   ├── domain-migration.md # setagayafes.org を第97回の正規ドメインにする手順
 │   ├── 96th-db-backup.md # 第96回 WordPress DBバックアップの検証情報と取扱い
 │   ├── seo-metadata.md # 共通metadata・canonicalとテストページ除外
-│   └── microcms.md   # microCMS API 制約と実装パターン
+│   ├── microcms.md   # microCMS API 制約と実装パターン
+│   └── content-revalidation.md # microCMS Webhook によるオンデマンド再検証と運用手順
 ├── frontend/         # フロントエンド関連ドキュメント
 │   ├── design.md                  # デザインシステム（カラー・タイポグラフィトークン）
 │   ├── access-page-design.md      # Accessページの情報設計・UI実装方針
@@ -148,6 +149,14 @@ docs/
   - カスタムフィールドのネスト制約と作成順序（子から親へ）。API をまたいだ参照は不可
   - **管理画面はブラウザ自動操作で編集できない。** 種類選択が実マウスイベントに依存し、スクリプトでは別の行へ適用される
   - **下書きコンテンツで動作確認はできない。** `draftKey` は保存のたびに変わり失効する。表示確認はダミーを直接渡す一時ページで行う
+
+- **[content-revalidation.md](./dev/content-revalidation.md)** - コンテンツ反映の仕組み（オンデマンド再検証）
+  - microCMS Webhook（`POST /api/revalidate`）を主系、時間ベース ISR を保険とする二段構え
+  - **`revalidatePath` はパスの API ではなくタグの API。** `/about` や `type` 無しの動的ルートは、エラーにならず静かに何もしない
+  - microCMS 側の設定手順。**削除・公開終了の通知タイミングは既定 OFF** で、ONにしないと「消したのに残る」が直らない
+  - **`pnpm dev` ではキャッシュ挙動を検証できない。** dev は全エントリを常に stale 扱いにする
+  - 障害切り分け表（Webhook 実行履歴 → Vercel ログ → `x-vercel-cache`）
+  - microCMS を読むページを増やしたときの対応表更新手順
 
 ### フロントエンド関連（frontend/）
 

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -41,6 +41,32 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 > CI（`feature-ci.yml`）は Lint / Format / Build の検証だけなので、公開フラグが未登録でも **`false` としてビルドが通る**。
 > **つまり CI が緑でも、公開状態のページがビルドできることは何も検証していない。**
 
+### Vercel のみに登録する変数（GitHub には登録しない）
+
+| 変数名                    | 内容                                      | 登録先                                         |
+| ------------------------- | ----------------------------------------- | ---------------------------------------------- |
+| `MICROCMS_WEBHOOK_SECRET` | microCMS Webhook の署名検証用シークレット | `.env.example` / Vercel（Production・Preview） |
+
+> [!IMPORTANT]
+> **`MICROCMS_WEBHOOK_SECRET` を GitHub Secrets と `feature-ci.yml` に登録してはいけない。**
+> `src/app/api/revalidate/route.ts` がリクエスト受信時にしか読まないため、ビルドには一切不要である。
+> 未設定でもビルドは通る（実行時に 500 を返す fail closed 設計）。
+> **これは登録漏れではなく意図的な除外である。** 後から「他の microCMS 変数と揃っていない」と
+> 判断して追加しないこと。CI に秘密情報を増やす理由がない。
+
+> [!WARNING]
+> **Vercel への登録は、microCMS 側で Webhook を作成する「前」に済ませること。**
+> 順序を逆にすると、シークレット未設定の間の入稿が 500 で拒否される。
+> **microCMS の Webhook は失敗しても再送されないため、その入稿の再検証は永久に失われる。**
+> 詳細は [content-revalidation.md](./content-revalidation.md)。
+
+### フラグ以外の変数を追加したときの判断基準
+
+| 読むタイミング                   | 登録先                                                             |
+| -------------------------------- | ------------------------------------------------------------------ |
+| ビルド時（`NEXT_PUBLIC_*` 等）   | `.env.example` / GitHub Variables or Secrets / Vercel / 本ファイル |
+| リクエスト時（Route Handler 内） | `.env.example` / Vercel / 本ファイル（GitHub は不要）              |
+
 ## ワークフローでの参照例
 
 ```yaml

--- a/docs/dev/content-revalidation.md
+++ b/docs/dev/content-revalidation.md
@@ -1,0 +1,216 @@
+# コンテンツ反映の仕組み（オンデマンド再検証）
+
+microCMS の入稿を本番へ反映させる経路と、その運用・障害切り分けをまとめる。
+
+- 実装: [`src/app/api/revalidate/route.ts`](../../src/app/api/revalidate/route.ts)
+- 対応表: [`src/lib/revalidate-targets.ts`](../../src/lib/revalidate-targets.ts)
+- 経緯: [Issue #141](https://github.com/ManatoYamashita/tcu-setagayafes97-web/issues/141)
+
+## 二段構え
+
+| 系統     | 手段                                                                  | 反映までの時間         |
+| -------- | --------------------------------------------------------------------- | ---------------------- |
+| **主系** | microCMS Webhook → `POST /api/revalidate` → `revalidatePath()`        | 数秒                   |
+| **保険** | 各ページの `export const revalidate`（3600 / `/special/[id]` は 600） | 最大1時間＋1リクエスト |
+
+**microCMS の Webhook は失敗しても再送されない。** 通知が届かなかった場合に永久に古いままにならないよう、
+時間ベース ISR は削除せず残してある。Webhook を入れたからといって `revalidate` 宣言を消してはいけない。
+
+### 導入前の状態（2026-08-30 実測）
+
+```
+$ curl -sI https://setagayafes.org/ | grep -iE '^(age|x-vercel-cache)'
+age: 4104
+x-vercel-cache: STALE
+```
+
+時間ベース ISR は stale-while-revalidate なので、実効遅延は
+「`revalidate` の経過 **＋ 誰かが1回アクセスすること**」だった。期限切れ後の最初の訪問者は必ず古い画面を受け取る。
+
+Webhook 経由の再検証はこれと挙動が違う。**プロファイル無しの `revalidatePath()` は即時失効**であり、
+キャッシュ読み取りは SWR ではなくハードミスになる。**発火後の最初の訪問者から新しい内容が出る。**
+ローカルの本番ビルドで実測済み（下記「検証」参照）。
+
+> `revalidateTag(tag, "max")` のようにプロファイルを渡すと SWR 挙動に戻る。
+> 将来タグ方式へ移行する場合はここを取り違えないこと。
+
+## 再検証の仕組み — `revalidatePath` はパスの API ではない
+
+Next.js は各キャッシュエントリに `_N_T_` 接頭辞の暗黙タグを付けて保存し、
+`revalidatePath(path, type)` はそこから組み立てたタグ1つを失効させる。
+実際の値はビルド成果物 `.next/server/app/**/*.meta` の `x-next-cache-tags` に入っている。
+
+この性質から、次の3つが**エラーにならず静かに何もしない**。
+
+| 書き方                                   | 生成されるタグ           | 結果                                                       |
+| ---------------------------------------- | ------------------------ | ---------------------------------------------------------- |
+| `revalidatePath("/about")`               | `_N_T_/about`            | **no-op。** 実体は `/ja/about` で、タグも `_N_T_/ja/about` |
+| `revalidatePath("/events/[id]")`         | （警告のみ）             | **no-op。** 動的ルートには `type` が要る                   |
+| `revalidatePath("/sitemap.xml", "page")` | `_N_T_/sitemap.xml/page` | **no-op。** メタデータルートの派生タグは `/route`          |
+
+正しい書き方は `src/lib/revalidate-targets.ts` の表にある。**この表を更新したら必ず実測で裏を取ること。**
+
+```bash
+pnpm build
+# 対応表の全パスを、実際に記録されたタグと突き合わせる
+grep -rho '"x-next-cache-tags":"[^"]*"' .next/server/app --include=*.meta | tr ',' '\n' | sort -u
+```
+
+> 公開フラグが `false` の間は `generateStaticParams()` が空を返し、
+> `/events/[id]` `/info/[id]` のページが1枚も生成されない＝タグも記録されない。
+> 動的ルートを検証するときは `NEXT_PUBLIC_EVENTS_VISIBLE=true NEXT_PUBLIC_NEWS_VISIBLE=true pnpm build` で確認する。
+
+## microCMS 側の設定手順
+
+> [!IMPORTANT]
+> **Vercel への環境変数登録を先に済ませること。** 順序を逆にすると、シークレット未設定の間の入稿が
+> 500 で拒否され、再送もされないまま静かに失われる。
+
+1. シークレットを生成する
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. Vercel の `Settings > Environment Variables` に `MICROCMS_WEBHOOK_SECRET` を登録する
+   （**Production と Preview の両方**）
+
+3. microCMS 管理画面で `news` / `events` / `informations` の **3 API それぞれに**
+   Webhook を追加する（Webhook は API ごとの設定で、1つで3 API を賄うことはできない）
+
+   `https://setagayafes97.microcms.io/apis/{endpoint}/settings/webhook` → 「追加」→「カスタム通知」
+
+   | 項目                       | 値                                       |
+   | -------------------------- | ---------------------------------------- |
+   | Webhook の名前             | `Vercel 再検証` など任意                 |
+   | URL                        | `https://setagayafes.org/api/revalidate` |
+   | シークレット               | 手順1で生成した値                        |
+   | カスタムリクエストヘッダー | 不要（署名検証を採用しているため）       |
+
+4. **通知タイミングを設定する。既定のままでは不十分。**
+
+   | カテゴリ                                | 設定    | 理由                                               |
+   | --------------------------------------- | ------- | -------------------------------------------------- |
+   | コンテンツの公開時・更新時（7項目）     | ✅ ON   | 既定で ON                                          |
+   | コンテンツの公開終了時（5項目）         | ✅ ON   | **既定 OFF。** 非公開化の反映に必須                |
+   | 公開中コンテンツの削除時（2項目）       | ✅ ON   | **既定 OFF。**「消したのに本番に残る」の解消に必須 |
+   | 公開終了コンテンツの削除時（2項目）     | ✅ ON   | **既定 OFF**                                       |
+   | コンテンツの下書き保存時                | ❌ OFF  | 下書きは本番に出ない。執筆中に無駄な発火をする     |
+   | 下書きコンテンツの削除時 / 下書き破棄時 | ❌ OFF  | 同上                                               |
+   | APIの設定変更時 / APIの削除時           | ⚠️ 任意 | 運用上ほぼ発生しない                               |
+
+   「並び替え」「コンテンツIDの変更」「公開日時の変更」は一覧の並び順や URL に直結するため**すべて ON**。
+
+> [!WARNING]
+> **削除系の3カテゴリを ON にし忘れると、Webhook を入れても「削除したのに本番に残る」は直らない。**
+> 導入後の検証で必ず削除を試すこと（下記）。
+
+## 検証
+
+### ローカル（本番ビルドで行うこと）
+
+**`pnpm dev` ではキャッシュ挙動を確認できない。** dev サーバはすべてのエントリを常に stale 扱いにするため、
+「新しい内容が出た」ことが再検証の成果なのか dev の仕様なのか区別がつかない。
+
+```bash
+pnpm build
+MICROCMS_WEBHOOK_SECRET=dev-secret PORT=3210 pnpm start
+```
+
+別のシェルで:
+
+```bash
+SECRET='dev-secret'
+URL='http://localhost:3210/api/revalidate'
+sig() { node -e 'process.stdout.write(require("node:crypto").createHmac("sha256",process.argv[1]).update(process.argv[2]).digest("hex"))' "$SECRET" "$1"; }
+hdr() { curl -sS -o /dev/null -D - "http://localhost:3210$1" | grep -i '^x-nextjs-cache' | tr -d '\r'; }
+BODY='{"service":"setagayafes97","api":"events","id":"abc123","type":"edit"}'
+
+# --- HTTP 契約 ---
+curl -sS -w '\n%{http_code}\n' -X POST "$URL" -H 'content-type: application/json' \
+  -H "x-microcms-signature: $(sig "$BODY")" --data-raw "$BODY"          # 200
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST "$URL" --data-raw "$BODY"  # 401（署名なし）
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST "$URL" \
+  -H 'x-microcms-signature: deadbeef' --data-raw "$BODY"                # 401（署名不正）
+curl -sS -o /dev/null -w '%{http_code}\n' "$URL"                        # 405（GET）
+
+# --- キャッシュ破棄 ---
+hdr /; hdr /                                                            # MISS → HIT
+curl -sS -o /dev/null -X POST "$URL" -H "x-microcms-signature: $(sig "$BODY")" --data-raw "$BODY"
+hdr /                                                                   # MISS ← ここが STALE なら失敗
+hdr /                                                                   # HIT
+```
+
+> `-d` ではなく `--data-raw` を使う。`-d` は先頭の `@` をファイル名として解釈し、改行を除去するため、
+> **署名した文字列と送信するバイト列がずれて必ず 401 になる。**
+
+未知の `api` の 400 を試すときは、**変更したボディで署名を計算し直す**こと。
+使い回すと 401 で止まり、400 の分岐に到達しない。
+
+### 本番（マージ後）
+
+Production デプロイの完成を待つ（マージから実測45〜85秒）。
+
+1. microCMS で `news` を1件更新する
+2. 5〜10秒待ってから、**1回だけ**叩く
+
+   ```bash
+   curl -sS -o /dev/null -D - https://setagayafes.org/ | grep -iE '^(age|x-vercel-cache)'
+   ```
+
+   `x-vercel-cache: MISS` / `age: 0` かつ更新内容が出ていれば成功。`STALE` なら失敗。
+
+   > [!CAUTION]
+   > **連続ポーリング禁止。** Vercel の bot 対策が発動して `x-vercel-mitigated: challenge` の 403 が
+   > 返り続け、サイト障害と見分けがつかなくなる（2026-08-29 に実際に踏んでいる）。
+   > 詳細は [ci-env.md の「Vercel の本番反映」](./ci-env.md)。
+
+3. Vercel の Functions ログに `[revalidate] api=news ... paths=...` が出ていることを確認
+4. microCMS の Webhook 実行履歴でステータス 200 を確認
+5. **削除の検証（本丸）**: テスト用の企画を1件削除し、`/events` から消えることを確認。
+   ここが通らなければ通知タイミングの「公開中コンテンツの削除時」が OFF のまま
+
+## 障害切り分け
+
+「microCMS を更新したのに本番に出ない」と報告されたとき、上から順に見る。
+
+| #   | 確認する場所                       | 症状と対処                                                                                                                                            |
+| --- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | microCMS の Webhook 実行履歴       | **記録が無い** → 通知タイミングが OFF。削除・公開終了は既定 OFF                                                                                       |
+| 2   | 同上のステータス                   | **401** → Vercel と microCMS のシークレット不一致。**500** → `MICROCMS_WEBHOOK_SECRET` が Vercel に未登録。**400** → 未知の `api`（対応表の更新漏れ） |
+| 3   | Vercel の Functions ログ           | `[revalidate]` の行が無い → Webhook の URL が誤っている                                                                                               |
+| 4   | 同上の `paths=`                    | **そのページが並んでいない** → `src/lib/revalidate-targets.ts` の対応表に漏れがある                                                                   |
+| 5   | `curl -sS -o /dev/null -D - <URL>` | `x-vercel-cache: HIT` のまま変わらない → タグが一致していない。`.meta` の実測タグと突き合わせる                                                       |
+
+## Webhook では解決しないこと
+
+- **公開フラグ `NEXT_PUBLIC_*_VISIBLE` はビルド時に評価される。**
+  Webhook では切り替わらない。解禁作業には従来どおり再デプロイが要る（[ci-env.md](./ci-env.md)）。
+- `EVENTS_VISIBLE=false` の間は `getEventsList()` が microCMS へ問い合わせず `[]` を返すため、
+  再検証しても表示は「準備中」のまま。これは正常な挙動。
+- **トップの「おすすめ企画」は再検証のたびに並びが変わる。**
+  `getFeaturedEvents()` が毎レンダーでシャッフルする仕様のため（`src/lib/events.ts`）。
+
+## microCMS を読むページを増やすとき
+
+`src/lib/revalidate-targets.ts` の対応表を**同じコミットで**更新すること。
+漏れてもエラーにはならず、そのページだけ静かに古いまま残る。
+
+ページ本体だけでなく、**そのページが描画する Server Component が読むデータも数える。**
+`/` の `SponsorBanner`（`informations`）や `FeaturedEvents`（`events`）がその例で、
+ページファイルの import だけを見ていると取りこぼす。
+
+```bash
+# microCMS を読むコンポーネントの洗い出し
+grep -rn 'from "@/lib/\(events\|news\|informations\)"' src/
+```
+
+## 関連ドキュメント
+
+- [docs/dev/microcms.md](./microcms.md) — microCMS API の制約と実装パターン
+- [docs/dev/ci-env.md](./ci-env.md) — 環境変数の登録先と Vercel の本番反映
+- [.claude/CLAUDE.md](../../.claude/CLAUDE.md) — プロジェクト全体のガイド
+
+---
+
+**最終更新日**: 2026-08-30

--- a/docs/dev/microcms.md
+++ b/docs/dev/microcms.md
@@ -184,9 +184,10 @@ microCMS 管理画面のフィールド種類選択ダイアログは、**実マ
 
 ## 関連ドキュメント
 
+- [docs/dev/content-revalidation.md](./content-revalidation.md) — Webhook によるオンデマンド再検証と運用手順
 - [.claude/CLAUDE.md](../../.claude/CLAUDE.md) — microCMS API 設計（フィールド定義）
 - [docs/requires/require.md](../requires/require.md) — 要件定義書
 
 ---
 
-**最終更新日**: 2026-08-16
+**最終更新日**: 2026-08-30

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -8,6 +8,20 @@ import { SponsorBanner } from "@/components/home/SponsorBanner";
 import { createPageMetadata } from "@/lib/metadata";
 
 /**
+ * 再検証間隔（Webhook 障害時のフォールバック）
+ *
+ * このページは末尾で `<SponsorBanner />` を描画しており、その中で microCMS の
+ * `informations` を読んでいる。主系は Webhook によるオンデマンド再検証
+ * （`src/app/api/revalidate/route.ts`）で、こちらは通知を取りこぼしたときの保険である。
+ *
+ * **この宣言を外すと新規協賛が永久に反映されなくなる。**
+ * 宣言が無い間、`/{ja,en,zh,ko}/about` は `initialRevalidateSeconds: false` であり、
+ * 同じ `informations` を `revalidate = 3600` で描画している `/about/sponsors` と
+ * 食い違っていた。値を揃えてある。
+ */
+export const revalidate = 3600;
+
+/**
  * 静的パラメータ生成
  */
 export function generateStaticParams() {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,160 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { isMicrocmsApi, REVALIDATE_TARGETS } from "@/lib/revalidate-targets";
+
+/**
+ * microCMS Webhook 受け口（オンデマンド再検証）
+ *
+ * microCMS の「カスタム通知」Webhook から POST を受け取り、該当ページのキャッシュを破棄する。
+ * 対応表は `src/lib/revalidate-targets.ts` にある。
+ *
+ * 各ページの `export const revalidate` は削除していない。microCMS の Webhook は
+ * **失敗しても再送されない**ため、通知の取りこぼしを時間ベース ISR が拾う二段構えにしている。
+ *
+ * 環境変数:
+ * - MICROCMS_WEBHOOK_SECRET: microCMS の Webhook 設定で入力したシークレット。
+ *   `x-microcms-signature`（HMAC-SHA256 の16進文字列）の検証に使う。
+ *   **未設定のときは 500 を返してすべてのリクエストを拒否する（fail closed）。**
+ *   キャッシュ破棄という副作用を持つ以上、検証できない状態で素通しさせない。
+ *   Vercel への登録は、microCMS 側の Webhook を作成する**前に**済ませること。
+ *   順序を逆にすると、最初の数回の入稿が 500 で静かに失われる。
+ *
+ * 運用手順・障害切り分けは docs/dev/content-revalidation.md を参照。
+ */
+
+/** microCMS が署名を載せてくるヘッダー名 */
+const SIGNATURE_HEADER = "x-microcms-signature";
+
+/**
+ * Webhook ペイロード。
+ *
+ * 意図的に緩くしてある。「並び替え」「コンテンツIDの変更」「APIの設定変更」など
+ * `id` を持たない通知タイミングが存在するため、`id` を必須にするとそれらが 400 で弾かれ、
+ * 一覧の並び順が更新されなくなる。このエンドポイントが実際に使うのは `api` だけである。
+ */
+const webhookPayloadSchema = z.object({
+  api: z.string().min(1),
+  id: z.string().optional(),
+  type: z.string().optional(),
+  service: z.string().optional(),
+  contents: z.unknown().optional(),
+});
+
+/**
+ * 署名を検証する。
+ *
+ * microCMS は「シークレットで生のリクエストボディを HMAC-SHA256 した16進文字列」を
+ * `x-microcms-signature` に載せてくる。
+ *
+ * 比較はタイミング攻撃を避けるため `timingSafeEqual` を使う。長さが違うと例外を投げる仕様なので
+ * 先に弾く。16進文字列のまま比較しているのは、`Buffer.from(x, "hex")` が不正な文字を
+ * 黙って切り捨てる（例外を投げない）ためで、文字列同士なら解釈の余地が入らない。
+ */
+function verifySignature(rawBody: Buffer, signature: string | null, secret: string): boolean {
+  if (!signature) {
+    return false;
+  }
+
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const received = Buffer.from(signature, "utf8");
+  const computed = Buffer.from(expected, "utf8");
+
+  if (received.length !== computed.length) {
+    return false;
+  }
+
+  return timingSafeEqual(received, computed);
+}
+
+/**
+ * POST: microCMS からの通知を受けて再検証する
+ *
+ * 順序に意味がある。署名の検証を JSON のパースより先に置くことで、
+ * 認証されていないリクエストに対してパース処理を一切走らせない。
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const secret = process.env.MICROCMS_WEBHOOK_SECRET;
+
+    if (!secret) {
+      console.error(
+        "[revalidate] MICROCMS_WEBHOOK_SECRET が未設定です。署名を検証できないため、リクエストを受け付けません。"
+      );
+
+      return NextResponse.json(
+        { success: false, error: "Webhook is not configured." },
+        { status: 500 }
+      );
+    }
+
+    /*
+     * 署名は「送られてきたバイト列そのもの」に対して計算されている。
+     * request.json() で読むと再シリアライズで空白やキー順が変わり、署名は必ず一致しなくなる。
+     * request.text() でも UTF-8 のデコードと再エンコードを経るため、バイト列を直接扱う。
+     *
+     * ボディサイズのガードは置いていない。ここへ到達した時点で本文は既にバッファ済みであり、
+     * 事後のチェックは保護になっていない。実際の上限は Vercel の 4.5MB が担保する。
+     */
+    const rawBody = Buffer.from(await request.arrayBuffer());
+
+    if (!verifySignature(rawBody, request.headers.get(SIGNATURE_HEADER), secret)) {
+      console.error("[revalidate] 署名の検証に失敗しました。リクエストを破棄します。");
+
+      return NextResponse.json({ success: false, error: "Invalid signature." }, { status: 401 });
+    }
+
+    let json: unknown;
+
+    try {
+      json = JSON.parse(rawBody.toString("utf8"));
+    } catch {
+      console.error("[revalidate] ボディが JSON として解釈できません。");
+
+      return NextResponse.json({ success: false, error: "Invalid JSON body." }, { status: 400 });
+    }
+
+    const parsed = webhookPayloadSchema.safeParse(json);
+
+    if (!parsed.success) {
+      console.error("[revalidate] 想定外のペイロードです:", parsed.error.flatten().fieldErrors);
+
+      return NextResponse.json(
+        { success: false, error: "Unexpected webhook payload." },
+        { status: 400 }
+      );
+    }
+
+    const { api, id, type } = parsed.data;
+
+    /*
+     * 未知の API は 400 で返す。microCMS の Webhook 実行履歴にエラーとして残るため、
+     * API を増やしたのに src/lib/revalidate-targets.ts の対応表を更新し忘れたことに気づける。
+     */
+    if (!isMicrocmsApi(api)) {
+      console.error(`[revalidate] 未知の api です: ${api}`);
+
+      return NextResponse.json({ success: false, error: `Unknown api: ${api}` }, { status: 400 });
+    }
+
+    const targets = REVALIDATE_TARGETS[api];
+
+    for (const target of targets) {
+      revalidatePath(target.path, target.type);
+    }
+
+    const revalidated = targets.map((target) => target.path);
+
+    // Vercel の Functions ログで発火を確認する唯一の手段になるため、成功時も必ず1行残す。
+    console.log(
+      `[revalidate] api=${api} id=${id ?? "-"} type=${type ?? "-"} paths=${revalidated.join(",")}`
+    );
+
+    return NextResponse.json({ success: true, api, revalidated, now: Date.now() });
+  } catch (error) {
+    console.error("[revalidate] 再検証中にエラーが発生しました:", error);
+
+    return NextResponse.json({ success: false, error: "Revalidation failed." }, { status: 500 });
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,20 @@ import { getNewsList } from "@/lib/news";
 import { siteConfig, SPECIAL_VISIBLE } from "@/data/site";
 
 /**
+ * 再検証間隔（Webhook 障害時のフォールバック）
+ *
+ * 主系は microCMS Webhook によるオンデマンド再検証（`src/app/api/revalidate/route.ts`）で、
+ * こちらは通知を取りこぼしたときの保険である。microCMS の Webhook は失敗しても再送されない。
+ *
+ * **この宣言を外すと新規コンテンツが永久に sitemap へ出なくなる。**
+ * 宣言が無い間、`.next/prerender-manifest.json` の `/sitemap.xml` は
+ * `initialRevalidateSeconds: false`（＝時間経過では再生成されない）だった。
+ * このファイルは events / news の両方を読むため、再デプロイするまで新規企画も
+ * 新規お知らせも sitemap に載らない状態になる。
+ */
+export const revalidate = 3600;
+
+/**
  * サイトマップ自動生成
  * Next.js 14+ の sitemap.ts ファイルで動的生成
  */

--- a/src/lib/revalidate-targets.ts
+++ b/src/lib/revalidate-targets.ts
@@ -1,0 +1,109 @@
+/**
+ * microCMS の API（エンドポイント名）と、その内容を描画しているページの対応表。
+ *
+ * `src/app/api/revalidate/route.ts` が Webhook を受けたときに、ここを引いて
+ * `revalidatePath()` を呼ぶ。`src/i18n/localized-pathnames.ts` と同じ性格のモジュールで、
+ * 「app ディレクトリの実態と同期していなければならない知識」を1箇所に閉じ込めている。
+ *
+ * ## 仕組み: revalidatePath はパスの API ではなくタグの API である
+ *
+ * Next.js は各キャッシュエントリに `_N_T_` 接頭辞の暗黙タグを付けて保存し、
+ * `revalidatePath(path, type)` はそこから組み立てたタグ1つを失効させる。
+ * ビルド成果物の `.next/server/app/**\/*.meta` に実際の値が入っている。
+ *
+ * | エントリ            | 記録されているタグ（抜粋）                                          |
+ * | ------------------- | ------------------------------------------------------------------- |
+ * | `ja/about.meta`     | `_N_T_/[locale]/about/layout`, `_N_T_/[locale]/about/page`, `_N_T_/ja/about` |
+ * | `sitemap.xml.meta`  | `_N_T_/sitemap.xml/route`, `_N_T_/sitemap.xml`                       |
+ *
+ * **この表を更新したら、上記 `.meta` に対象タグが実在するかを文字列一致で確認すること。**
+ * 存在しないタグを指定してもエラーにはならず、そのページだけ静かに古いまま残る。
+ *
+ * ```bash
+ * pnpm build
+ * grep -rho 'x-next-cache-tags[^"]*' .next/server/app --include=*.meta
+ * ```
+ *
+ * ## 動的ルートは「パターン形」で指定する
+ *
+ * `/events/[id]` は `RelatedEvents` で**他の**企画を、`/info/[id]` は関連ニュースを並べる。
+ * つまり1件の変更で全詳細ページの関連セクションが古くなるため、
+ * 該当 id だけを再検証しても足りない。パターン形 `["/events/[id]", "page"]` は
+ * `_N_T_/events/[id]/page` を叩き、その全インスタンスにまとめて当たる。
+ * 送るタグは1つだけで、再生成は実際にアクセスされたページでしか起きない。
+ *
+ * `type` を省略すると Next.js は警告を出したうえで**何も再検証しない**。動的ルートには必ず付ける。
+ *
+ * ## ロケール接頭辞のあるページに `/about` と書いてはいけない
+ *
+ * next-intl の `localePrefix: "as-needed"` により、`/about` の実体は `/ja/about` である。
+ * キャッシュエントリが持つのも `_N_T_/ja/about` であって `_N_T_/about` ではないため、
+ * `revalidatePath("/about")` は**一致するタグが存在せず何もしない。**
+ * `["/[locale]/about", "page"]` なら ja/en/zh/ko の4つすべてに1回で当たる。
+ *
+ * ## 最終手段
+ *
+ * `revalidatePath("/", "layout")` は `_N_T_/layout` を叩く。これは全エントリが持つタグなので
+ * サイト全体が失効し、この対応表のドリフトとは無縁になる。
+ * **採用しない。** microCMS を読まない `/access` や `/info/guide` まで巻き込んで
+ * 毎回の入稿で無駄に再生成させるため。対応表の維持が破綻したときの逃げ道としてだけ覚えておく。
+ */
+
+/** 本プロジェクトが使う microCMS の API。増やしたら REVALIDATE_TARGETS もビルドが通らなくなる */
+export const MICROCMS_APIS = ["news", "events", "informations"] as const;
+
+export type MicrocmsApi = (typeof MICROCMS_APIS)[number];
+
+export interface RevalidateTarget {
+  /** `revalidatePath()` へ渡すパス。動的ルートは `[id]` を含むパターン形で書く */
+  readonly path: string;
+  /** 動的ルートのパターン形に必須。静的パスとメタデータルートでは付けない */
+  readonly type?: "page";
+}
+
+/**
+ * API → 再検証するパス。
+ *
+ * ページ本体だけでなく、そのページが描画する Server Component が読むデータも数えること
+ * （`/` の `SponsorBanner` や `FeaturedEvents` がその例）。
+ *
+ * `Record<MicrocmsApi, ...>` にしてあるので、`MICROCMS_APIS` へ4つ目を足すと
+ * ここを埋めるまでビルドが通らない。テストの無いこのリポジトリで唯一のドリフト検知になっている。
+ */
+export const REVALIDATE_TARGETS: Record<MicrocmsApi, readonly RevalidateTarget[]> = {
+  // getNewsList / getLatestHeroNews / getNewsById
+  news: [
+    { path: "/" }, // Hero の最新お知らせ + News セクション
+    { path: "/info" },
+    { path: "/info/[id]", type: "page" }, // 詳細 + 関連ニュース一覧
+    { path: "/sitemap.xml" },
+  ],
+
+  // getEventsList / getFeaturedEvents / getEventById / getSpecialEvents / getSpecialEventById
+  events: [
+    { path: "/" }, // FeaturedEvents + SpecialGuestSection
+    { path: "/events" }, // 一覧 + SpecialGuestSection
+    { path: "/events/[id]", type: "page" }, // 詳細 + RelatedEvents
+    { path: "/timetable" },
+    { path: "/special" },
+    { path: "/special/[id]", type: "page" },
+    { path: "/sitemap.xml" },
+  ],
+
+  // getSponsorsList / getFAQList
+  informations: [
+    { path: "/" }, // SponsorBanner
+    { path: "/about/sponsors" },
+    { path: "/[locale]/about", type: "page" }, // SponsorBanner（4ロケール）
+    { path: "/[locale]/info/faq", type: "page" },
+  ],
+};
+
+/**
+ * 受け取った文字列が既知の microCMS API かどうか。
+ *
+ * `src/i18n/localized-pathnames.ts` の `isLocalizedPathname()` と同じ形の型ガード。
+ */
+export function isMicrocmsApi(value: string): value is MicrocmsApi {
+  return (MICROCMS_APIS as readonly string[]).includes(value);
+}


### PR DESCRIPTION
Closes #141

## 何を解決するか

microCMS の入稿が本番へ反映されるまで最大1時間かかっていた。Vercel の ISR は stale-while-revalidate なので、実効遅延は「`revalidate` の経過 **＋** 誰かが1回アクセスすること」であり、**期限切れ後の最初の訪問者は必ず古い画面を受け取る**。

`POST /api/revalidate` を新設し、microCMS のカスタム通知 Webhook から `revalidatePath()` を呼ぶ。**発火から数秒で反映される。**

## 実装

| ファイル | 内容 |
| --- | --- |
| `src/app/api/revalidate/route.ts` | Webhook 受け口（新規）。HMAC-SHA256 署名検証つき |
| `src/lib/revalidate-targets.ts` | API → パスの対応表（新規） |
| `src/app/sitemap.ts` | `export const revalidate = 3600` を追加 |
| `src/app/[locale]/about/page.tsx` | 同上 |
| `.env.example` / `docs/` ×4 | 環境変数と運用ランブック |

### 各ページの `revalidate` は削除していない

**microCMS の Webhook は失敗しても再送されない。** 通知を取りこぼしたときに永久に古いままにならないよう、時間ベース ISR を保険として残す二段構えにしている。

### Issue の表に無かった2件も直した

`/sitemap.xml` と `/{ja,en,zh,ko}/about` は `initialRevalidateSeconds: false`、つまり**ビルド時に1度作られたきり再生成されない**状態だった。前者は events + news を、後者は `<SponsorBanner />` 経由で informations を読んでいる。

> 新規企画も新規協賛も、再デプロイするまで**永久に**出てこない。「最大1時間」ですらなかった。

同じ `informations` を描画する `/about/sponsors` は `revalidate = 3600` であり、`/about` だけ無限だった不整合も解消した。

### 動的ルートは「ルートパターン」で再検証する

`revalidatePath("/events/[id]", "page")` を使い、個別 id では叩かない。`/events/[id]` は `RelatedEvents` で**他の**企画を、`/info/[id]` は関連ニュースを並べるため、1件の変更で全詳細ページの関連セクションが古くなるからである。送るタグは1つだけで、再生成は実際にアクセスされたページでしか起きない。

## 実測での確認

`revalidatePath` はパスの API ではなく**タグの API** である。ビルド成果物 `.next/server/app/**/*.meta` に記録された実タグと、対応表の全パスを突き合わせた。

```
OK  news         /                     -     → _N_T_/
OK  news         /info/[id]            page  → _N_T_/info/[id]/page
OK  events       /events/[id]          page  → _N_T_/events/[id]/page
OK  informations /[locale]/about       page  → _N_T_/[locale]/about/page
OK  informations /[locale]/info/faq    page  → _N_T_/[locale]/info/faq/page
    ... 15/15 一致・不一致 0
```

あわせて、**採用しなかった書き方が no-op になること**も確認した。

| 書き方 | 結果 |
| --- | --- |
| `revalidatePath("/about")` | タグ不在 → 静かに何もしない（実体は `/ja/about`） |
| `revalidatePath("/events/[id]")`（type 無し） | 同上 |
| `revalidatePath("/sitemap.xml", "page")` | 同上（派生タグは `/route`） |

### キャッシュ破棄の挙動（本番ビルドで実測）

`pnpm dev` は全エントリを常に stale 扱いにするため検証に使えない。`pnpm build && pnpm start` で確認した。

```
1) ウォームアップ            → MISS → HIT
2) events の Webhook 発火    → HTTP 200
3) 発火直後の最初の訪問者    → MISS   ← STALE ではない。ブロッキング再生成
4) 2人目                     → HIT

5) 対照実験（informations を発火）
   / は対象           → MISS
   /timetable は対象外 → HIT      ← 過剰な無効化をしていない
```

### HTTP 契約

| ケース | 期待 | 結果 |
| --- | --- | --- |
| 正しい署名 | 200 | ✅ `{"success":true,"revalidated":[...]}` |
| 署名ヘッダなし / 不正 / 長さ違い | 401 | ✅ ×3 |
| 未知の `api` | 400 | ✅ `Unknown api: blogs` |
| 署名は正しいが JSON でない | 400 | ✅ |
| `api` フィールドが無い | 400 | ✅ |
| GET | 405 | ✅ |
| **シークレット未設定（fail closed）** | 500 | ✅ 正しい署名でも拒否 |

`pnpm lint` エラー 0（警告7件はすべて既存）、`pnpm format:check` 通過、`pnpm build` 成功。

## マージ後に必要な手動作業

> [!IMPORTANT]
> **1 → 2 の順序を守ること。** 逆にすると、シークレット未設定の間の入稿が 500 で拒否され、**再送されないため永久に失われる。**

1. `openssl rand -hex 32` で生成した値を、Vercel の `MICROCMS_WEBHOOK_SECRET` へ登録（**Production / Preview の両方**）
2. microCMS の `news` / `events` / `informations` の**3 API それぞれに**カスタム通知を追加
   - URL: `https://setagayafes.org/api/revalidate` / シークレット: 手順1の値
   - **通知タイミング: 「公開終了時」「公開中コンテンツの削除時」「公開終了コンテンツの削除時」を ON にする。**
     ここは既定 OFF で、忘れると「消したのに本番に残る」が Webhook を入れても直らない
3. 検証: 企画を1件削除し、`/events` から消えることを確認

手順の全文と障害切り分け表は [`docs/dev/content-revalidation.md`](https://github.com/ManatoYamashita/tcu-setagayafes97-web/blob/feature/microcms-webhook-revalidate/docs/dev/content-revalidation.md) にある。

`MICROCMS_WEBHOOK_SECRET` は**リクエスト時にしか読まないため GitHub Secrets には登録しない**。意図的な除外であることを `docs/dev/ci-env.md` に明記した。

## 本 PR では解決しないこと

- **公開フラグ `NEXT_PUBLIC_*_VISIBLE` はビルド時評価であり、Webhook では切り替わらない。** 解禁作業には従来どおり再デプロイが要る
- `RelatedEvents` が企画詳細の描画ごとに `getEventsList(200)` を呼んでいる。再検証が増えると microCMS の転送量（Hobby: 20GB/月）を押す可能性がある。今回は変更していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134JQ8xLW5SURuscR5RZPxh
