### PR TITLE
CI: 型チェックを Static Checks へ追加する（#157 段階1）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,6 +69,9 @@ pnpm start
 # Lintチェック
 pnpm lint
 
+# 型チェック（next typegen で .next/types を作り直してから tsc --noEmit）
+pnpm type-check
+
 # フォーマットチェック
 pnpm format:check
 
@@ -101,7 +104,7 @@ refactor/<refactor-target> # リファクタリング
 
 **CI のカバー範囲:**
 
-`.github/workflows/feature-ci.yml`（Lint & Format Check / Build Check）は次の場合に走る。**上記5つの命名規則から外れたブランチ名を使うと、push 時のチェックが一切走らない。**
+`.github/workflows/feature-ci.yml`（Static Checks / Build Check）は次の場合に走る。**上記5つの命名規則から外れたブランチ名を使うと、push 時のチェックが一切走らない。**
 
 | イベント       | 対象                                                             |
 | -------------- | ---------------------------------------------------------------- |
@@ -109,6 +112,18 @@ refactor/<refactor-target> # リファクタリング
 | `pull_request` | base が `main` または `dev`                                      |
 
 push 時は head をそのまま、PR 時は head を base へマージした結果を検証する。**両方走る場合、それは重複ではなく別種の検証である。**
+
+`Static Checks` は **`pnpm install` だけで完結する検査**（lint / format / 型）を束ねたジョブである。
+secrets もビルド成果物も要求しないため、**fork からの PR でも結果が出る**（`Build Check` は
+microCMS の secrets を要求するので fork PR では必ず落ちる）。ここへ検査を足すときは、
+「install 以外に何も要求しないか」を基準に判断すること。要求するなら別ジョブにする。
+
+`pnpm type-check` が `next typegen` を前置しているのは、**`.next/types/validator.ts` が
+`.d.ts` ではなく `.ts` だから**である。`skipLibCheck: true` はこのファイルを守らないため、
+ルートを消したり改名したりした後に古い `validator.ts` が残っていると、
+`tsc` が生成物の中で `TS2307` を出して落ちる（2026-09-03 実測）。typegen が作り直せば消える。
+CI はクリーンチェックアウトなので陳腐化しないが、**ローカルと CI で同じコマンドを使うために
+スクリプト側へ入れてある。**
 
 もう1本、`.github/workflows/production-deploy-guard.yml` が `main` への push で走る。
 そのコミットの Vercel Production デプロイが作られたかを最大5分間確認し、現れなければ失敗する。

--- a/.github/workflows/feature-ci.yml
+++ b/.github/workflows/feature-ci.yml
@@ -18,8 +18,10 @@ on:
       - dev
 
 jobs:
-  lint-and-format:
-    name: Lint & Format Check
+  # pnpm install だけで完結する検査をここへ束ねる。
+  # secrets もビルド成果物も要求しないため、fork からの PR でも結果が出る。
+  static-checks:
+    name: Static Checks
     runs-on: ubuntu-latest
 
     steps:
@@ -45,6 +47,12 @@ jobs:
 
       - name: Run Prettier check
         run: pnpm run format:check
+
+      # next build も型エラーで落ちる（ignoreBuildErrors 未設定）が、この検査は
+      # 別に置く。secrets から独立していて数十秒で落ちること、そして
+      # ignoreBuildErrors: true を1行足せば build 側の型検査だけは消せてしまうため。
+      - name: Run type check
+        run: pnpm run type-check
 
   build:
     name: Build Check

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cp .env.example .env.local
 | `pnpm build`        | プロダクションビルド       |
 | `pnpm start`        | プロダクションサーバー起動 |
 | `pnpm lint`         | ESLint チェック            |
+| `pnpm type-check`   | TypeScript 型チェック      |
 | `pnpm format`       | Prettier 自動修正          |
 | `pnpm format:check` | フォーマットチェック       |
 | `pnpm analyze`      | バンドル分析               |

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -38,7 +38,7 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 
 > [!NOTE]
 > **この表は「登録すべきもの」であって、現状の登録一覧ではない。** `gh variable list` で確認できるのは `NEXT_PUBLIC_URL` のみ。
-> CI（`feature-ci.yml`）は Lint / Format / Build の検証だけなので、公開フラグが未登録でも **`false` としてビルドが通る**。
+> CI（`feature-ci.yml`）は Lint / Format / 型 / Build の検証だけなので、公開フラグが未登録でも **`false` としてビルドが通る**。
 > **つまり CI が緑でも、公開状態のページがビルドできることは何も検証していない。**
 
 ### Vercel のみに登録する変数（GitHub には登録しない）
@@ -446,9 +446,9 @@ curl -s https://<production deployment url>/robots.txt | grep Sitemap
 ## 関連ドキュメント
 
 - [docs/dev/git.md](./git.md) — ブランチ戦略と CI/CD ワークフロー
-- `.github/workflows/feature-ci.yml` — Lint / Format / Build の検証
+- `.github/workflows/feature-ci.yml` — Static Checks（Lint / Format / 型）と Build Check
 - `.github/workflows/production-deploy-guard.yml` — `main` への push で Production デプロイの作成を確認
 
 ---
 
-**最終更新日**: 2026-09-02
+**最終更新日**: 2026-09-03

--- a/docs/dev/git.md
+++ b/docs/dev/git.md
@@ -103,6 +103,10 @@ feature ブランチへの push 時に自動実行される品質チェック：
   - コードフォーマット規約準拠確認
   - インデント、改行、引用符などの統一性検証
 
+- **型チェック**
+  - 型定義の整合性検証
+  - ビルドと重複しても、secrets を要求せず短時間で落ちる検査として価値がある
+
 - **ビルドチェック**
   - ビルド成功確認
   - ビルドサイズ計測（必要に応じて）
@@ -116,9 +120,19 @@ feature ブランチへの push 時に自動実行される品質チェック：
 - name: Run format check
   run: npm run format:check
 
+- name: Run type check
+  run: npm run type-check
+
 - name: Run build
   run: npm run build
 ```
+
+> [!NOTE]
+> **本リポジトリの実装は上記テンプレートとは異なる。** `feature-ci.yml` は
+> `Static Checks`（lint / format / 型）と `Build Check` の2ジョブで、PR の自動作成は行わない。
+> ジョブを分ける基準は「`pnpm install` 以外に何を要求するか」である。
+> install だけで済む検査は `Static Checks` に束ね、secrets やビルド成果物、
+> ブラウザを要求する検査は別ジョブにする。
 
 #### 2. Create Pull Request Job
 
@@ -540,3 +554,4 @@ git push origin feature-add-gtm
 - 2026-08-16: `.github/workflows/` の push が拒否される場合の回避手順を追加
 - 2026-08-29: 「ステージングの規約」を追加（`git add -A` / `git add .` の禁止、コミット前チェックリスト、巻き込み時の復旧手順）
 - 2026-08-29: 「マージ前の検証」を追加（`merge-tree` で消えるファイルを確認、worktree での実動確認、マージ前チェックリスト）
+- 2026-09-03: `feature-ci.yml` に型チェックを追加し、`lint-and-format` を `static-checks` へ改名（#157 段階1）

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint src/",
+    "type-check": "next typegen && tsc --noEmit",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",


### PR DESCRIPTION
Closes #157 の段階1。

## 何をしたか

`pnpm type-check`（`next typegen && tsc --noEmit`）を追加し、CI の `lint-and-format` ジョブを
`static-checks` / `Static Checks` へ改名してそこへ足した。

新ジョブにしなかったのは、セットアップ4ステップ（checkout / pnpm / node / install）が
既に2ジョブへ重複記述されており、独立ジョブを立てると3重複になるため。`tsc` の前提は
lint と完全に同一（`pnpm install` 済みの `node_modules` だけ）で、並列化しても
クリティカルパスは常に `build` なので待ち時間は縮まない。

改名が安全なのは、`main` にブランチ保護も ruleset も無く required status checks が
存在しないため（`gh api` で 404 / `[]` を確認済み）。参照は `.claude/CLAUDE.md` の1箇所だけで、
同時に更新した。

## `next build` と重複していることについて

事実として重複している（`next.config.ts` に `ignoreBuildErrors` が無いので `next build` は
既に型エラーで落ちる）。それでも別に置く理由は3つ。

- 数十秒で落ちる
- secrets / env から独立していて、fork PR でも結果が出る
- `ignoreBuildErrors: true` を1行足せば build 側の型検査は消せるが、`tsc` ステップは残る

後から「重複だから消そう」と言われたときに答えられるよう、`docs/dev/git.md` に根拠を残した。

## `next typegen` を前置している理由（実測で差し替え済み）

**当初の想定は3つとも外れた。** 実測した結果を正直に書く。

| 当初の想定 | 実測（2026-09-03） |
| --- | --- |
| typed routes の検査が CI で失われる | `typedRoutes` が未有効。`<Link href="/infooo">` は typegen の有無に関わらず**通る** |
| `readonly NODE_ENV` は `next-env.d.ts` 経由でのみ効く | どちらでも TS2540 になる。**CI とローカルの非対称ではない** |
| `rm -rf .next` の直後にローカルの `tsc` が落ちる | `skipLibCheck: true` が `next-env.d.ts` を守るため**落ちない** |

`validator.ts` の生成型も props に `& any` が付いており、ページの `params` を
`Promise` から素のオブジェクトへ壊しても検出しなかった。

**それでも typegen を残したのは、別の実効が見つかったから。** `.next/types/validator.ts` は
`.d.ts` ではなく **`.ts`** なので `skipLibCheck` に守られない。ルートを消したり改名したりした後に
古い `validator.ts` が残っていると、`tsc` が生成物の中で `TS2307` を出して落ちる。

```
.next/types/validator.ts(152,39): error TS2307: Cannot find module '../../src/app/info/pamphlet/page.js'
```

`next typegen` が作り直せばこれは消える（実測で再現・解消を確認）。CI はクリーンチェックアウトなので
陳腐化しないが、**ローカルと CI で同じコマンドを使うため**スクリプト側へ入れている。

## 検証

```
rm -rf .next next-env.d.ts tsconfig.tsbuildinfo && pnpm type-check   # exit 0
git status --short                                                   # tsconfig.json に差分なし
env -u MICROCMS_SERVICE_DOMAIN -u MICROCMS_API_KEY pnpm type-check   # OK（secrets 不要）
```

**ネガティブ検証。** `parseTimeToMinutes` の戻り値型を `number | null` → `number` にすると
`TS2322` が3件出て落ちることを確認した（Issue の表「型で検出可」の検算）。

```
src/lib/timetable-layout.ts(75,14): error TS2322: Type 'null' is not assignable to type 'number'.
src/lib/timetable-layout.ts(78,17): error TS2322: Type 'null' is not assignable to type 'number'.
src/lib/timetable-layout.ts(82,35): error TS2322: Type 'null' is not assignable to type 'number'.
```

## 後続

この PR を base に段階2（`feature/timetable-unit-tests`）と段階3（`feature/timetable-layout-e2e`）が
積んである。`feature-ci.yml` を3本とも触るため、`main` から個別に切ると確実に衝突する。
**PR1 → PR2 → PR3 の順にマージしてください。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiPEd66ahPoYS3NRNcHWx2
