### PR TITLE
FIX: 1未満のページ番号で別ページが返るのを修正し、filters.ts にユニットテストを追加する

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -102,6 +102,16 @@ it("…", async () => {
 `vi.stubEnv("NODE_ENV", "production")` を使うこと。
 `vitest.config.mts` の `unstubEnvs: true` がテストごとに巻き戻す。
 
+### 似た名前の関数でも契約が違うことがある
+
+`src/lib/filters.ts` の `filterEvents()` は `date` を**厳密一致**で扱い、`"day1"` の絞り込みに
+`date: "both"` の企画を含めない。`src/lib/timetable.ts` の `filterEventsByDate()` は
+**含める。** どちらも正しい。
+
+`/events` は `dateFilterOptions` に「両日開催」を独立した選択肢として持つのに対し、
+`/timetable` は Day1 / Day2 のタブしか無いためである。**片方に揃えると、もう片方の UI が壊れる。**
+両方をテストで固定してあるので、揃えようとすると赤くなる。
+
 ### `vitest.config.mts` の拡張子は `.ts` ではない
 
 `.ts` にすると Vite が「CommonJS として読んだファイルに ESM 構文がある」と警告し、
@@ -133,6 +143,15 @@ it("…", async () => {
 | 選択中ステージをタブから落とす             | 選択中のステージを当日0件でも残す                            |
 | レンジの最低1時間を外す                    | 同一の正時に収まる企画でも最低1時間を確保する                |
 
+`src/lib/filters.ts` にも同じ手順を踏んだ（2026-09-03、#162）。
+
+| 退行させた内容                                | 落ちたテスト                                          |
+| --------------------------------------------- | ----------------------------------------------------- |
+| `paginateEvents` の1未満クランプを削除        | 1未満のページは空配列を返す／小数のページを切り捨てる |
+| `Math.floor` による小数の切り捨てをやめる     | 小数のページを切り捨てる                              |
+| `filterEvents` の `date` 判定に `both` を足す | date を厳密一致で扱い、両日開催を1日目に含めない      |
+| `generatePageNumbers` の窓幅を 7 から 5 へ    | 上記4つの不変条件を検査するプロパティテストを含む6件  |
+
 **新しくテストを足すときも同じ手順を踏むこと。** 壊しても赤くならないなら、
 そのテストは何も固定していない。
 
@@ -143,7 +162,7 @@ it("…", async () => {
 | 対象                                                                          | 判断           |
 | ----------------------------------------------------------------------------- | -------------- |
 | `src/lib/timetable-layout.ts` / `src/lib/timetable.ts` / `src/data/stages.ts` | 導入済み       |
-| `src/lib/filters.ts`（`generatePageNumbers` の窓計算）                        | 足す価値がある |
+| `src/lib/filters.ts`                                                          | 導入済み       |
 | `src/lib/revalidate-targets.ts`                                               | 型が守っている |
 | `src/lib/utils.ts`（`cn`）                                                    | 不要           |
 | `sessionStorage` / `window` に依存するもの（`motion.ts` 等）                  | 実ブラウザ側   |

--- a/src/components/timetable/__fixtures__/stage-events.ts
+++ b/src/components/timetable/__fixtures__/stage-events.ts
@@ -41,7 +41,7 @@ const BASE = {
 export function fixture(
   id: string,
   overrides: Pick<Event, "date" | "type" | "place" | "title" | "organizer"> &
-    Partial<Pick<Event, "startTime" | "endTime" | "building">>
+    Partial<Pick<Event, "startTime" | "endTime" | "building" | "description">>
 ): Event {
   return { ...BASE, id, ...overrides };
 }

--- a/src/lib/filters.test.ts
+++ b/src/lib/filters.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterEvents,
+  generatePageNumbers,
+  getTotalPages,
+  paginateEvents,
+  type FilterParams,
+} from "@/lib/filters";
+import { fixture } from "@/components/timetable/__fixtures__/stage-events";
+import type { Event } from "@/types/events";
+
+const ids = (events: Event[]): string[] => events.map((event) => event.id);
+
+/**
+ * `/events` の絞り込み用データ
+ *
+ * `date` は day1 / day2 / both / other を1件ずつ持たせている。
+ * 「両日開催」を独立した選択肢として扱う契約を検証するため。
+ */
+const events: Event[] = [
+  fixture("ev-day1", {
+    date: "day1",
+    type: "room",
+    place: "1101教室",
+    building: "1号館",
+    title: "化学実験ショー",
+    organizer: "化学部",
+    description: "身近な材料でできる実験を披露します。",
+  }),
+  fixture("ev-day2", {
+    date: "day2",
+    type: "stage",
+    place: "7A ステージ",
+    building: "7号館",
+    title: "Jazz Live",
+    organizer: "ジャズ研究会",
+    description: "スタンダードナンバーを演奏します。",
+  }),
+  fixture("ev-both", {
+    date: "both",
+    type: "room",
+    place: "2201教室",
+    building: "2号館",
+    title: "鉄道模型展示",
+    organizer: "鉄道研究会",
+    description: "ジオラマの走行展示を行います。",
+  }),
+  fixture("ev-other", {
+    date: "other",
+    type: "special",
+    place: "体育館 メインアリーナ",
+    building: "体育館",
+    title: "前夜祭",
+    organizer: "実行委員会",
+    description: "前日の限定企画です。",
+  }),
+];
+
+describe("filterEvents", () => {
+  it("フィルタ未指定なら全件返す", () => {
+    expect(ids(filterEvents(events, {}))).toEqual(ids(events));
+  });
+
+  it('"all" は素通しする', () => {
+    const filters: FilterParams = { date: "all", type: "all", building: "all", keyword: "" };
+    expect(ids(filterEvents(events, filters))).toEqual(ids(events));
+  });
+
+  it("date を厳密一致で扱い、両日開催を1日目に含めない", () => {
+    // /events は dateFilterOptions に「両日開催」を独立した選択肢として持つ。
+    // Day1 / Day2 のタブしか無い /timetable の filterEventsByDate() が
+    // "both" を両方へ出すのとは、意図的に異なる契約である。
+    expect(ids(filterEvents(events, { date: "day1" }))).toEqual(["ev-day1"]);
+    expect(ids(filterEvents(events, { date: "day2" }))).toEqual(["ev-day2"]);
+    expect(ids(filterEvents(events, { date: "both" }))).toEqual(["ev-both"]);
+    expect(ids(filterEvents(events, { date: "other" }))).toEqual(["ev-other"]);
+  });
+
+  it("type と building も厳密一致で扱う", () => {
+    expect(ids(filterEvents(events, { type: "room" }))).toEqual(["ev-day1", "ev-both"]);
+    expect(ids(filterEvents(events, { building: "7号館" }))).toEqual(["ev-day2"]);
+  });
+
+  it("キーワードが5つのフィールドを横断する", () => {
+    expect(ids(filterEvents(events, { keyword: "化学実験ショー" }))).toEqual(["ev-day1"]); // title
+    expect(ids(filterEvents(events, { keyword: "ジャズ研究会" }))).toEqual(["ev-day2"]); // organizer
+    expect(ids(filterEvents(events, { keyword: "ジオラマ" }))).toEqual(["ev-both"]); // description
+    expect(ids(filterEvents(events, { keyword: "メインアリーナ" }))).toEqual(["ev-other"]); // place
+    expect(ids(filterEvents(events, { keyword: "2号館" }))).toEqual(["ev-both"]); // building
+  });
+
+  it("キーワードの大文字小文字を無視する", () => {
+    expect(ids(filterEvents(events, { keyword: "jazz" }))).toEqual(["ev-day2"]);
+    expect(ids(filterEvents(events, { keyword: "JAZZ" }))).toEqual(["ev-day2"]);
+  });
+
+  it("該当が無ければ空配列を返す", () => {
+    expect(filterEvents(events, { keyword: "存在しない語" })).toEqual([]);
+  });
+
+  it("複数の条件を AND で適用する", () => {
+    expect(ids(filterEvents(events, { type: "room", building: "2号館" }))).toEqual(["ev-both"]);
+    // 単独では該当するが、組み合わせると該当しない
+    expect(filterEvents(events, { type: "room", building: "7号館" })).toEqual([]);
+  });
+
+  it("引数の配列を破壊しない", () => {
+    const before = ids(events);
+    filterEvents(events, { date: "day1", keyword: "化学" });
+    expect(ids(events)).toEqual(before);
+  });
+});
+
+describe("getTotalPages", () => {
+  it("件数と1ページあたりの表示数から総ページ数を出す", () => {
+    expect(getTotalPages(0, 12)).toBe(0);
+    expect(getTotalPages(1, 12)).toBe(1);
+    expect(getTotalPages(12, 12)).toBe(1);
+    expect(getTotalPages(13, 12)).toBe(2);
+  });
+});
+
+describe("paginateEvents", () => {
+  /** ページ分割の検証にだけ使う連番データ */
+  const items: Event[] = Array.from({ length: 30 }, (_, index) =>
+    fixture(`item-${index + 1}`, {
+      date: "day1",
+      type: "room",
+      place: "教室",
+      title: `企画 ${index + 1}`,
+      organizer: "テスト",
+    })
+  );
+
+  it("1ページ目を切り出す", () => {
+    expect(ids(paginateEvents(items, 1, 12))).toEqual(ids(items.slice(0, 12)));
+  });
+
+  it("最終ページの端数を切り出す", () => {
+    const lastPage = paginateEvents(items, 3, 12);
+    expect(lastPage).toHaveLength(6);
+    expect(ids(lastPage)).toEqual(ids(items.slice(24)));
+  });
+
+  it("総ページ数を超えたページは空配列を返す", () => {
+    expect(paginateEvents(items, 4, 12)).toEqual([]);
+    expect(paginateEvents(items, 999, 12)).toEqual([]);
+  });
+
+  it("1未満のページは空配列を返す", () => {
+    // page は URL から検証なしに入る。始点が負のまま slice へ渡すと
+    // 末尾からの相対位置として解釈され、別のページが返る（#162）
+    expect(paginateEvents(items, 0, 12)).toEqual([]);
+    expect(paginateEvents(items, -1, 12)).toEqual([]);
+    expect(paginateEvents(items, -2, 12)).toEqual([]);
+  });
+
+  it("小数のページを切り捨てる", () => {
+    // ?page=1.5 が slice(6, 18) という半端な窓を返さないこと
+    expect(ids(paginateEvents(items, 1.5, 12))).toEqual(ids(paginateEvents(items, 1, 12)));
+  });
+
+  it("全ページを連結すると元の配列に戻る（欠けも重複も無い）", () => {
+    const perPage = 12;
+    const totalPages = getTotalPages(items.length, perPage);
+    const joined = Array.from({ length: totalPages }, (_, index) =>
+      paginateEvents(items, index + 1, perPage)
+    ).flat();
+
+    expect(ids(joined)).toEqual(ids(items));
+  });
+
+  it("引数の配列を破壊しない", () => {
+    const before = ids(items);
+    paginateEvents(items, 2, 12);
+    expect(ids(items)).toEqual(before);
+  });
+});
+
+describe("generatePageNumbers", () => {
+  const MAX_PAGES = 7;
+
+  it("総ページ数が上限以下なら全ページを返す", () => {
+    expect(generatePageNumbers(1, 5)).toEqual([1, 2, 3, 4, 5]);
+    expect(generatePageNumbers(1, MAX_PAGES)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("ページが無ければ空配列を返す", () => {
+    expect(generatePageNumbers(1, 0)).toEqual([]);
+  });
+
+  it("先頭付近では窓を左端に寄せる", () => {
+    expect(generatePageNumbers(1, 10)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(generatePageNumbers(4, 10)).toEqual([1, 2, 3, 4, 5, 6, 7]); // 左寄せの境界
+  });
+
+  it("中央では現在ページを挟む", () => {
+    expect(generatePageNumbers(5, 10)).toEqual([2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("末尾付近では窓を右端に寄せる", () => {
+    expect(generatePageNumbers(7, 10)).toEqual([4, 5, 6, 7, 8, 9, 10]); // 右寄せの境界
+    expect(generatePageNumbers(10, 10)).toEqual([4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it("範囲外の現在ページでも妥当な窓を返す", () => {
+    // currentPage は URL から検証なしに入るため、範囲外でも壊れないこと
+    expect(generatePageNumbers(0, 10)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(generatePageNumbers(-1, 10)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(generatePageNumbers(15, 10)).toEqual([4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  it("総ページ数1〜40の全組み合わせで4つの不変条件を満たす", () => {
+    for (let totalPages = 1; totalPages <= 40; totalPages++) {
+      for (let currentPage = 1; currentPage <= totalPages; currentPage++) {
+        const pages = generatePageNumbers(currentPage, totalPages);
+        const label = `(currentPage=${currentPage}, totalPages=${totalPages})`;
+
+        expect(pages, `長さ ${label}`).toHaveLength(Math.min(totalPages, MAX_PAGES));
+        expect(
+          pages.every((page, index) => index === 0 || page === pages[index - 1] + 1),
+          `昇順の連続 ${label}`
+        ).toBe(true);
+        expect(pages, `現在ページを含む ${label}`).toContain(currentPage);
+        expect(
+          pages.every((page) => page >= 1 && page <= totalPages),
+          `範囲内 ${label}`
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -55,10 +55,21 @@ export function filterEvents(events: Event[], filters: FilterParams): Event[] {
  * @param events 企画の配列
  * @param page 現在のページ番号（1から開始）
  * @param perPage 1ページあたりの表示件数
- * @returns ページネーションされた企画の配列
+ * @returns ページネーションされた企画の配列。存在しないページなら空配列
+ *
+ * **1未満のページを弾くこと。** `page` は URL のクエリから検証なしに入ります
+ * （`EventsContent` の `Number(searchParams.get("page")) || 1`。`-1` は truthy なので
+ * `|| 1` を素通りします）。始点が負のまま `slice()` へ渡すと末尾からの相対位置として
+ * 解釈され、**空でも1ページ目でもない「別のページ」が返ります**（#162）。
+ *
+ * 範囲外を空にするのは、`page > 総ページ数` が既にそうなっているのと揃えるためです。
  */
 export function paginateEvents(events: Event[], page: number, perPage: number): Event[] {
-  const startIndex = (page - 1) * perPage;
+  // 小数は切り捨てる。?page=1.5 が slice(6, 18) という半端な窓を返さないように
+  const safePage = Math.floor(page);
+  if (safePage < 1) return [];
+
+  const startIndex = (safePage - 1) * perPage;
   const endIndex = startIndex + perPage;
   return events.slice(startIndex, endIndex);
 }


### PR DESCRIPTION
Closes #162。#157 で「レビュー面積を絞る」ため後続へ回していた `src/lib/filters.ts` の宿題。

## 何をしたか

`/events` のフィルタとページネーションを担う4関数に **ユニットテスト24件**を追加し、
書く準備の途中で見つけた実バグ（#162）を同じ PR で修正した。

## 実バグ: 1未満のページ番号

`paginateEvents()` は `slice((page - 1) * perPage, ...)` で切り出すため、`page` が 1 未満だと
始点が負になり、`Array.prototype.slice` が末尾からの相対位置として解釈する。

30件・12件/ページでの実測:

| `page` | 修正前 | 修正後 |
| --- | --- | --- |
| `0` | `[]` | `[]` |
| `999` | `[]` | `[]` |
| **`-1`** | **7〜18件目（12件）** | `[]` |
| **`-2`** | **1〜6件目** | `[]` |
| `1.5` | 7〜18件目 | 1〜12件目（1ページ目へ畳む） |

`src/components/events/EventsContent.tsx:31` が `Number(searchParams.get("page")) || 1` で
URL のクエリを検証せずに受けている。`"-1"` は truthy なので `|| 1` を素通りする。

**現状の挙動をテストで固定するとバグを仕様に格上げしてしまう**ため、テストと同じ PR で直した。

```ts
const safePage = Math.floor(page);
if (safePage < 1) return [];
```

範囲外を空にするのは、`page > 総ページ数` が既にそうなっているのと揃えるため。
呼び出し側での検証も考えたが、`paginateEvents()` が単体で誤った窓を返す状態は
呼び出し元が増えたときに再発するので、足元を直した。

## テストで固定した不変条件

### `filterEvents` の `date` は厳密一致（意図的な差の明示）

`filterEvents()` は `"day1"` の絞り込みに `date: "both"` の企画を**含めない**。
`src/lib/timetable.ts` の `filterEventsByDate()` は**含める**。**どちらも正しい。**

`/events` は `dateFilterOptions` に「両日開催」を**独立した選択肢**として持つのに対し、
`/timetable` は Day1 / Day2 のタブしか無いため。**片方に揃えると、もう片方の UI が壊れる。**
両方をテストで固定してあるので、揃えようとすると赤くなる。

その他、`type` / `building` の厳密一致、キーワードが `title` / `organizer` / `description` /
`place` / `building` の5フィールドを横断すること、大文字小文字を無視すること、
複数条件が AND であること、引数配列を破壊しないことを固定した。

### `generatePageNumbers` はプロパティテストで総当たり

窓計算は分岐が入り組んでおり、代表値だけでは境界の取りこぼしが読み切れない。
`totalPages 1〜40 × currentPage 1〜totalPages` の全組み合わせで次の4つを検査している。

- 長さ = `min(totalPages, 7)`
- 昇順の連続した整数
- `currentPage` を必ず含む
- 全要素が `[1, totalPages]` の範囲内

**この関数自体にバグは無かった**（範囲外の `currentPage` でも妥当な窓を返す）。テストは
現状の健全さを固定するためのもの。

### `paginateEvents` / `getTotalPages`

境界に加えて「**全ページを連結すると元の配列に戻る**（欠けも重複も無い）」を総則として置いた。

## ネガティブ検証

**テストを書いただけでは何も守れていない。** 実装を退行させて赤くなることを確認した。

| 退行させた内容 | 結果 | 落ちたテスト |
| --- | --- | --- |
| `paginateEvents` の1未満クランプを削除 | 2 failed | 1未満のページは空配列を返す／小数のページを切り捨てる |
| `Math.floor` による切り捨てをやめる | 1 failed | 小数のページを切り捨てる |
| `filterEvents` の `date` 判定に `both` を足す | 1 failed | date を厳密一致で扱い、両日開催を1日目に含めない |
| `generatePageNumbers` の窓幅を 7 → 5 | 6 failed | プロパティテストを含む6件 |

## 検証

```
pnpm test        # 104 passed（既存80 + 新規24）
pnpm test:e2e    # 15 passed（/timetable に影響が無いことの確認）
pnpm lint / format:check / type-check / build   # すべて OK
```

## 本体コードへの変更

- `src/lib/filters.ts` — `paginateEvents` のクランプ（#162 の修正）
- `src/components/timetable/__fixtures__/stage-events.ts` — `overrides` の型へ `description` を1語追加。
  キーワード検索が5フィールドを横断することを、1件ずつ別の語で検証するため

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiPEd66ahPoYS3NRNcHWx2
