### PR TITLE
FIX: /events のページ本体を静的HTMLへ戻す（#156）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -343,6 +343,13 @@ microCMS の入稿は **Webhook 経由で数秒以内**に本番へ反映され�
 
 現在の転送一覧と設計判断は [`docs/dev/domain-migration.md`](../docs/dev/domain-migration.md) を参照。
 
+> [!IMPORTANT]
+> **同じ `loading.tsx` の境界は `useSearchParams()` の bailout も飲み込む。** 境界を書き忘れた
+> Client Component があると、エラーにならないまま**ページ本体が静的HTMLから丸ごと消える**
+> （#148 = `/timetable`、#156 = `/events`）。`/events` を捕まえていたのはルートではなく
+> `src/app/events/loading.tsx` である。判定方法・fallback の設計・実測値は
+> [`docs/frontend/static-html-and-search-params.md`](../docs/frontend/static-html-and-search-params.md) を参照。
+
 > [!WARNING]
 > `src/app/events/[id]/page.tsx` の `type=special` → `/special/[id]` 誘導は
 > ページ内 `redirect()` のままであり、上記のとおり 200 + meta refresh になっている。

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -277,6 +277,14 @@ docs/
   - **列の `height` を `minHeight` へ変えるだけでは落ちない。** #148 の再現には `h-full` の中間ラッパが要る（実測記録あり）
   - 1024px 未満は盤面が `display:none` になり全アサーションが偽陰性。共通フィクスチャが測定条件を先に検査する
 
+- **[static-html-and-search-params.md](./frontend/static-html-and-search-params.md)** - `useSearchParams()` と静的HTML（#156）
+  - **境界を書かないとエラーにならず、いちばん近い `loading.tsx` が代役になる。** `/events` を捕まえていたのはルートではなく `src/app/events/loading.tsx`
+  - **境界を足すだけでは中身は静的HTMLに戻らない。** bailout は境界の内側を落とすものであり、戻すものではない
+  - **fallback はサーバーで描かれてHTMLに出る。** そこへ既定状態の完成形を置くと企画カードのリンクが載る
+  - **fallback の中で `useSearchParams()` を呼んではいけない**（それ以上落ちる先が無い）。下位からは props へ引き上げる
+  - 判定は `data-page-hero="true"` の綴りで行う。`grep -c` と属性名だけの grep はどちらも誤読する（flight ペイロードに別綴りで入っている）
+  - 実測: 静的HTMLの企画リンク 0 → 11本。転送量は brotli で +4.2KB。差し替えは約390ms、CLS 0
+
 - **[i18n-page-structure.md](./frontend/i18n-page-structure.md)** - 多言語ページの構成パターン
   - メッセージの二分割（ページ本文 `messages/` と ヘッダー・フッター `messages/chrome/`）
   - ページビューの置き場所（同名ルートの二重実装がデッドコード化する罠）

--- a/docs/frontend/static-html-and-search-params.md
+++ b/docs/frontend/static-html-and-search-params.md
@@ -1,0 +1,139 @@
+# `useSearchParams()` と静的HTML
+
+`useSearchParams()` を使う Client Component は、**書き方を1つ間違えるとページ本体を静的HTMLから
+丸ごと消します。** #148 / #154（`/timetable`）と #156（`/events`）で2回起きました。
+
+関連: [performance.md](./performance.md)（Lighthouse基準） /
+[layout-e2e.md](./layout-e2e.md)（実ブラウザでの実測） /
+[../dev/seo-metadata.md](../dev/seo-metadata.md)
+
+---
+
+## 何が起きるのか
+
+`useSearchParams()` は静的レンダリング時に、**最も近い `<Suspense>` 境界より内側**を
+クライアント描画へ落とします（bailout）。落ちた範囲は静的HTMLに入りません。
+
+**境界を書かなくてもエラーにはなりません。** 代わりに、いちばん近い `loading.tsx` が
+作る境界が代役を務めます。このアプリには2枚あります。
+
+| ファイル                     | 代役になる範囲                           |
+| ---------------------------- | ---------------------------------------- |
+| `src/app/loading.tsx`        | ルート直下。ヘッダー・フッター以外の全部 |
+| `src/app/events/loading.tsx` | `/events` のページ全体                   |
+
+> [!WARNING]
+> #156 の Issue 本文は「ルート直下の `src/app/loading.tsx` が捕まえる」と書いていますが、
+> `/events` を捕まえていたのは **`src/app/events/loading.tsx`** です（2026-09-03 実測）。
+> 範囲が同じなので結果は変わりませんが、原因を追うときは**そのルートに `loading.tsx` が
+> あるかを先に見る**こと。
+
+---
+
+## 判定方法 — 素朴な grep は誤読する
+
+生成物 `.next/server/app/<route>.html` を直接読みます。**属性の綴りまで含めて照合すること。**
+
+```bash
+NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build
+
+f=.next/server/app/events.html
+grep -o 'data-page-hero="true"' "$f" | wc -l    # ヒーローが描かれているか
+grep -o 'data-page-sheet="true"' "$f" | wc -l   # 白いシートが描かれているか
+grep -o 'href="/events/[a-zA-Z0-9_-]*"' "$f" | sort -u | wc -l
+```
+
+引っかかりやすい罠が2つあります。
+
+1. **`grep -c` を使わない。** HTML は改行の無い1行なので、`grep -c` は「行数」として常に 0 か 1 を返します。
+   個数を数えるなら `grep -o ... | wc -l`
+2. **`data-page-hero` だけで検索しない。** 落ちている状態でも 3 件ヒットします。RSC の
+   flight ペイロード（`self.__next_f.push`）の中に `\"data-page-hero\":true` という**別の綴り**で
+   入っているためです。描画されたHTMLに出るのは `data-page-hero="true"` のほう。
+   同様に `<title>` やヘッダーのナビにはページ名の文字列が出るので、`企画を探す` のような
+   語での grep も当てになりません
+
+bailout の位置は次で確認します。
+
+```bash
+grep -o '.\{160\}BAILOUT_TO_CLIENT_SIDE_RENDERING' "$f"
+```
+
+直前が `<div hidden id="S:0">` なら `loading.tsx` が代役になっています。
+自分で置いた `<Suspense>` の直前にあれば、意図どおり境界の内側で止まっています。
+
+---
+
+## 境界を足すだけでは中身は戻らない
+
+**bailout は「境界の内側をクライアント描画へ落とす」ものであって、内側をサーバー描画に
+戻すものではありません。** 境界を足すと落ちる範囲が縮むだけです。
+
+`<Suspense>` の **fallback はサーバーで描かれ、静的HTMLに出力されます**。したがって
+「中身をHTMLに載せたい」なら、**fallback をプレースホルダではなく既定状態の完成形にします。**
+
+`/events` では「クエリ無しで着地したときの表示」＝未フィルタ1ページ目を fallback に置きました
+（`src/app/events/page.tsx`）。
+
+```
+<Suspense fallback={<EventsView ...既定値... />}>   ← 静的HTMLに出る
+  <EventsContent initialEvents={events} />          ← "use client" / useSearchParams
+    └ <EventsView ... />                            ← 同じコンポーネント
+</Suspense>
+```
+
+> [!IMPORTANT]
+> **fallback の中で `useSearchParams()` を呼んではいけません。** fallback にはそれ以上
+> 落ちる先がありません。`/events` で `EventFilters` と `Pagination` から
+> `useSearchParams()` を外して props 化したのは、リファクタのついでではなく**この制約への対応**です。
+> クエリを読むのは `EventsContent` の1箇所だけに保ってください。
+
+---
+
+## 実測（2026-09-03 / Next.js 16.1.0 / `NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build`）
+
+`.next/server/app/events.html` を直接読んだ結果。
+
+| 確認項目                                  | 境界なし                    | 境界あり（fallback = 既定ビュー） |
+| ----------------------------------------- | --------------------------- | --------------------------------- |
+| `data-page-hero="true"`                   | 0                           | **1**                             |
+| `data-page-sheet="true"`                  | 0                           | **1**                             |
+| `href="/events/xxx"`（重複除く）          | 0                           | **11**                            |
+| `href="/special/xxx"`（重複除く）         | 0                           | **1**                             |
+| `件の企画が見つかりました`                | 0                           | **1**（＋flightペイロードに1）    |
+| `BAILOUT_TO_CLIENT_SIDE_RENDERING` の位置 | `events/loading.tsx` の境界 | 追加した `<Suspense>` の内側      |
+| HTML raw                                  | 81,635 bytes                | 184,964 bytes                     |
+| gzip -9                                   | 15,429 bytes                | 24,898 bytes                      |
+| brotli -q11                               | 12,780 bytes                | **16,990 bytes**                  |
+
+**転送量で見ると +4.2KB です。** raw では2.3倍に見えますが、HTMLと flight ペイロードに同じ
+マークアップが2度出るため圧縮がよく効きます。判断は必ず圧縮後の数字で行うこと。
+
+### 差し替えの体感（`pnpm start` / Playwright / クリーンなコンテキスト）
+
+fallback は hydrate されません。境界がクライアント描画へ落ちるとき、fallback の DOM は
+破棄されて本描画に差し替わります。**差し替わるまでフィルタのボタンは無反応です。**
+
+| 着地URL                               | fallback → 本描画 | CLS |
+| ------------------------------------- | ----------------- | --- |
+| `/events`                             | 388ms             | 0   |
+| `/events?type=stage`（18→15件）       | 384ms             | 0   |
+| `/events?type=room`（カード12枚→1枚） | 413ms             | 0   |
+| `/events?page=2`                      | 379ms             | 0   |
+
+クエリ付きで着地すると、差し替わるまでの数百ミリ秒は**未フィルタの一覧**が見えます。
+CLS が 0 なのは、スクロール位置0の視界をヒーローが占めており、折り返しより下の
+高さ変化が可視要素をずらさないためです（`?type=room` は文書高が 4,283 → 2,708px と
+大きく縮みますが、それでも 0）。
+
+---
+
+## 新しく `useSearchParams()` を使うとき
+
+1. そのルートに `loading.tsx` があるか確認する（あればそれが暗黙の境界になる）
+2. `<Suspense>` を置く。**包む範囲は最小に。** `/events` では Server Component である
+   著名人企画のセクションを境界の外に残し、静的HTMLへ残している
+3. fallback に「クエリ無しで着地したときの表示」を置けるか検討する。置けるなら、
+   そのために下位コンポーネントから `useSearchParams()` を props へ引き上げる
+4. ビルドして上記の grep を通す。**通ることは何も証明しません。** 境界を一時的に外して
+   数字が 0 に戻ることまで確かめること（[layout-e2e.md](./layout-e2e.md) と同じ作法）

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -1,7 +1,15 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { getEventsList } from "@/lib/events";
+import {
+  paginateEvents,
+  getTotalPages,
+  DEFAULT_EVENT_FILTERS,
+  EVENTS_PER_PAGE,
+} from "@/lib/filters";
 import { EventsContent } from "@/components/events/EventsContent";
+import { EventsView } from "@/components/events/EventsView";
 import { ComingSoon } from "@/components/common/ComingSoon";
 import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
 import { SpecialGuestSection } from "@/components/special/SpecialGuestSection";
@@ -97,8 +105,36 @@ export default async function EventsPage() {
         </Link>
       )}
 
-      {/* 企画一覧コンテンツ */}
-      <EventsContent initialEvents={events} />
+      {/*
+        企画一覧コンテンツ
+
+        EventsContent は useSearchParams() を使うため <Suspense> 境界が要る。
+        境界が無いと、src/app/events/loading.tsx が代役を務めてしまい、
+        ページ全体（ヒーローと白いシートを含む）がクライアントレンダリングへ落ちる。
+
+        fallback はただのプレースホルダではなく「クエリ無しで来たときの完成形」である。
+        bailout した境界の fallback はサーバーで描かれて静的HTMLに残るため、ここへ既定の
+        ビューを置くと企画カードのリンクがHTMLに載り、/events がクロール経路として機能する。
+        クエリ無しなら本描画と同一マークアップになるので、差し替わっても見た目は動かない。
+
+        DEFAULT_EVENT_FILTERS は絞り込み無しなので filterEvents() は恒等写像になる。
+        呼ばずに events をそのまま渡している。
+
+        詳細は docs/frontend/static-html-and-search-params.md を参照。
+      */}
+      <Suspense
+        fallback={
+          <EventsView
+            events={paginateEvents(events, 1, EVENTS_PER_PAGE)}
+            filters={DEFAULT_EVENT_FILTERS}
+            totalCount={events.length}
+            currentPage={1}
+            totalPages={getTotalPages(events.length, EVENTS_PER_PAGE)}
+          />
+        }
+      >
+        <EventsContent initialEvents={events} />
+      </Suspense>
 
       {/* 一覧を見終えた来場者をもう一度 LP へ送る。上部の細いリンクとは粒度が違うので併存させる */}
       {specialGuestSection}

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -1,37 +1,39 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
+import { eventsHref, type FilterParams } from "@/lib/filters";
 import { dateFilterOptions, typeFilterOptions, buildingFilterOptions } from "@/data/filter-options";
+
+interface EventFiltersProps {
+  /** 現在のフィルター。遷移先URLの組み立てと選択状態の表示に使う */
+  filters: FilterParams;
+}
 
 /**
  * 企画フィルターコンポーネント
  * URL Search Params で状態管理
+ *
+ * **現在値は `useSearchParams()` ではなく props で受け取ります。** このコンポーネントは
+ * `EventsView` 経由で `<Suspense>` の fallback にも描かれるため、ここでクエリを読むと
+ * fallback 自身が bailout し、ページ本体が静的HTMLから消えます（#156）。
+ * `useRouter()` は bailout を起こさないのでそのまま使えます。
  */
-export function EventFilters() {
+export function EventFilters({ filters }: EventFiltersProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
-  const currentDate = searchParams.get("date") || "all";
-  const currentType = searchParams.get("type") || "all";
-  const currentBuilding = searchParams.get("building") || "all";
-  const currentKeyword = searchParams.get("keyword") || "";
+  const currentDate = filters.date ?? "all";
+  const currentType = filters.type ?? "all";
+  const currentBuilding = filters.building ?? "all";
+  const currentKeyword = filters.keyword ?? "";
 
   /**
    * フィルター変更ハンドラー
+   *
+   * ページ番号は引き継ぎません（絞り込みを変えたら1ページ目へ戻す）。
+   * "all" と空文字は `eventsHref` がクエリから落とします。
    */
-  const handleFilterChange = (key: string, value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (value === "" || value === "all") {
-      params.delete(key);
-    } else {
-      params.set(key, value);
-    }
-
-    // ページネーションをリセット
-    params.delete("page");
-
-    router.push(`/events?${params.toString()}`);
+  const handleFilterChange = (patch: Partial<FilterParams>) => {
+    router.push(eventsHref({ ...filters, ...patch }));
   };
 
   /**
@@ -62,7 +64,7 @@ export function EventFilters() {
             {dateFilterOptions.map((option) => (
               <button
                 key={option.value}
-                onClick={() => handleFilterChange("date", option.value)}
+                onClick={() => handleFilterChange({ date: option.value })}
                 className={`rounded-full border px-4 py-2 text-sm font-medium transition-all ${
                   currentDate === option.value
                     ? "border-gray-200 bg-white text-primary"
@@ -83,7 +85,7 @@ export function EventFilters() {
             {typeFilterOptions.map((option) => (
               <button
                 key={option.value}
-                onClick={() => handleFilterChange("type", option.value)}
+                onClick={() => handleFilterChange({ type: option.value })}
                 className={`rounded-full border px-4 py-2 text-sm font-medium transition-all ${
                   currentType === option.value
                     ? "border-gray-200 bg-white text-primary"
@@ -108,7 +110,7 @@ export function EventFilters() {
           <select
             id="building-filter"
             value={currentBuilding}
-            onChange={(e) => handleFilterChange("building", e.target.value)}
+            onChange={(e) => handleFilterChange({ building: e.target.value })}
             className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-2 text-sm text-gray-900 focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
           >
             {buildingFilterOptions.map((option) => (
@@ -132,7 +134,7 @@ export function EventFilters() {
             id="keyword-search"
             placeholder="企画名、団体名などで検索"
             value={currentKeyword}
-            onChange={(e) => handleFilterChange("keyword", e.target.value)}
+            onChange={(e) => handleFilterChange({ keyword: e.target.value })}
             className="w-full rounded-lg border border-gray-200/30 bg-white/10 px-4 py-2 text-sm text-gray-900 placeholder-white/50 focus:border-gray-200 focus:outline-none focus:ring-2 focus:ring-white/20"
           />
         </div>

--- a/src/components/events/EventsContent.tsx
+++ b/src/components/events/EventsContent.tsx
@@ -1,34 +1,36 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
-import type { Event, EventDate, EventType } from "@/types/events";
-import { filterEvents, paginateEvents, getTotalPages, type FilterParams } from "@/lib/filters";
-import { EventGrid } from "./EventGrid";
-import { EventFilters } from "./EventFilters";
-import { Pagination } from "./Pagination";
+import type { Event } from "@/types/events";
+import {
+  filterEvents,
+  paginateEvents,
+  getTotalPages,
+  parseEventFilters,
+  parseEventPage,
+  EVENTS_PER_PAGE,
+} from "@/lib/filters";
+import { EventsView } from "./EventsView";
 
 interface EventsContentProps {
   initialEvents: Event[];
 }
 
-const EVENTS_PER_PAGE = 12;
-
 /**
  * 企画一覧コンテンツ
  * クライアントサイドでフィルタリング・ページネーション処理
+ *
+ * **このアプリで `/events` のクエリを読むのはここだけです。** `useSearchParams()` は
+ * 静的レンダリング時に「最も近い `<Suspense>` 境界より内側」をクライアント描画へ落とします。
+ * 読む場所を増やすと落ちる範囲が広がるため、下位（`EventFilters` / `Pagination`）へは
+ * 値を props で渡します。境界は `src/app/events/page.tsx` にあります（#156）。
  */
 export function EventsContent({ initialEvents }: EventsContentProps) {
   const searchParams = useSearchParams();
 
   // URL Search Params からフィルター情報を取得
-  const filters: FilterParams = {
-    date: (searchParams.get("date") as EventDate | "all") || "all",
-    type: (searchParams.get("type") as EventType | "all") || "all",
-    building: searchParams.get("building") || "all",
-    keyword: searchParams.get("keyword") || "",
-  };
-
-  const currentPage = Number(searchParams.get("page")) || 1;
+  const filters = parseEventFilters(searchParams);
+  const currentPage = parseEventPage(searchParams);
 
   // フィルタリング
   const filteredEvents = filterEvents(initialEvents, filters);
@@ -38,34 +40,12 @@ export function EventsContent({ initialEvents }: EventsContentProps) {
   const paginatedEvents = paginateEvents(filteredEvents, currentPage, EVENTS_PER_PAGE);
 
   return (
-    <div className="container mx-auto px-4 py-12">
-      <div className="lg:grid lg:grid-cols-[300px_1fr] lg:gap-8">
-        {/* サイドバー: フィルター */}
-        <aside className="mb-8 lg:mb-0">
-          <EventFilters />
-        </aside>
-
-        {/* メインコンテンツ */}
-        <main>
-          {/* 検索結果件数 */}
-          <div className="mb-6 flex items-center justify-between">
-            <p className="text-sm text-gray-900/80">
-              <span className="font-semibold text-gray-900">{filteredEvents.length}</span>{" "}
-              件の企画が見つかりました
-            </p>
-          </div>
-
-          {/* 企画グリッド */}
-          <EventGrid events={paginatedEvents} />
-
-          {/* ページネーション */}
-          {totalPages > 1 && (
-            <div className="mt-12">
-              <Pagination currentPage={currentPage} totalPages={totalPages} />
-            </div>
-          )}
-        </main>
-      </div>
-    </div>
+    <EventsView
+      events={paginatedEvents}
+      filters={filters}
+      totalCount={filteredEvents.length}
+      currentPage={currentPage}
+      totalPages={totalPages}
+    />
   );
 }

--- a/src/components/events/EventsView.tsx
+++ b/src/components/events/EventsView.tsx
@@ -1,0 +1,68 @@
+import type { Event } from "@/types/events";
+import type { FilterParams } from "@/lib/filters";
+import { EventGrid } from "./EventGrid";
+import { EventFilters } from "./EventFilters";
+import { Pagination } from "./Pagination";
+
+interface EventsViewProps {
+  /** 表示するページ分の企画（フィルタリング・ページネーション適用後） */
+  events: Event[];
+  /** 現在のフィルター。EventFilters と Pagination が遷移先URLの組み立てに使う */
+  filters: FilterParams;
+  /** フィルタリング後の総件数（「N 件の企画が見つかりました」の N） */
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+/**
+ * 企画一覧の表示ツリー
+ *
+ * **`useSearchParams()` に依存させないこと。** これは意図的な制約です。
+ *
+ * このツリーは `src/app/events/page.tsx` の `<Suspense>` の fallback としても描かれます。
+ * fallback は「境界がクライアント描画へ落ちたときに静的HTMLへ出力されるもの」であり、
+ * その中で `useSearchParams()` を呼ぶと fallback 自身が bailout して落ちる先を失います。
+ * クエリを読むのは `EventsContent` の1箇所だけに保ってください。
+ *
+ * 背景と実測は docs/frontend/static-html-and-search-params.md を参照。
+ */
+export function EventsView({
+  events,
+  filters,
+  totalCount,
+  currentPage,
+  totalPages,
+}: EventsViewProps) {
+  return (
+    <div className="container mx-auto px-4 py-12">
+      <div className="lg:grid lg:grid-cols-[300px_1fr] lg:gap-8">
+        {/* サイドバー: フィルター */}
+        <aside className="mb-8 lg:mb-0">
+          <EventFilters filters={filters} />
+        </aside>
+
+        {/* メインコンテンツ */}
+        <main>
+          {/* 検索結果件数 */}
+          <div className="mb-6 flex items-center justify-between">
+            <p className="text-sm text-gray-900/80">
+              <span className="font-semibold text-gray-900">{totalCount}</span>{" "}
+              件の企画が見つかりました
+            </p>
+          </div>
+
+          {/* 企画グリッド */}
+          <EventGrid events={events} />
+
+          {/* ページネーション */}
+          {totalPages > 1 && (
+            <div className="mt-12">
+              <Pagination filters={filters} currentPage={currentPage} totalPages={totalPages} />
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/Pagination.tsx
+++ b/src/components/events/Pagination.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { generatePageNumbers } from "@/lib/filters";
+import { useRouter } from "next/navigation";
+import { eventsHref, generatePageNumbers, type FilterParams } from "@/lib/filters";
 
 interface PaginationProps {
+  /** 現在のフィルター。ページを移動しても絞り込みを保つために要る */
+  filters: FilterParams;
   currentPage: number;
   totalPages: number;
 }
@@ -11,24 +13,20 @@ interface PaginationProps {
 /**
  * ページネーションコンポーネント
  * URL Search Params で状態管理
+ *
+ * **現在のクエリは `useSearchParams()` ではなく props で受け取ります。** 理由は
+ * `EventFilters` と同じで、`<Suspense>` の fallback に描かれても bailout しないためです（#156）。
  */
-export function Pagination({ currentPage, totalPages }: PaginationProps) {
+export function Pagination({ filters, currentPage, totalPages }: PaginationProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   /**
    * ページ変更ハンドラー
+   *
+   * `page === 1` はクエリから落ちる（`eventsHref` の仕様）。
    */
   const handlePageChange = (page: number) => {
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (page === 1) {
-      params.delete("page");
-    } else {
-      params.set("page", page.toString());
-    }
-
-    router.push(`/events?${params.toString()}`);
+    router.push(eventsHref(filters, page));
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 

--- a/src/lib/filters.test.ts
+++ b/src/lib/filters.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildEventsQuery,
+  DEFAULT_EVENT_FILTERS,
+  eventsHref,
   filterEvents,
   generatePageNumbers,
   getTotalPages,
   paginateEvents,
+  parseEventFilters,
+  parseEventPage,
   type FilterParams,
 } from "@/lib/filters";
 import { fixture } from "@/components/timetable/__fixtures__/stage-events";
@@ -228,5 +233,102 @@ describe("generatePageNumbers", () => {
         ).toBe(true);
       }
     }
+  });
+});
+
+/**
+ * クエリの読み書き
+ *
+ * `EventFilters` / `Pagination` から `useSearchParams()` を外した際に、URL の組み立てを
+ * この純粋関数へ移した（#156）。以前は「現在URLのクエリ文字列を起点に足し引きする」実装
+ * だったため、**props から組み直しても等価であること**がこの関数の契約になる。
+ */
+describe("parseEventFilters", () => {
+  it("未指定の項目を既定値で埋める", () => {
+    expect(parseEventFilters(new URLSearchParams())).toEqual(DEFAULT_EVENT_FILTERS);
+  });
+
+  it("指定された項目をそのまま読む", () => {
+    const params = new URLSearchParams("date=day1&type=stage&building=7号館&keyword=軽音");
+
+    expect(parseEventFilters(params)).toEqual({
+      date: "day1",
+      type: "stage",
+      building: "7号館",
+      keyword: "軽音",
+    });
+  });
+});
+
+describe("parseEventPage", () => {
+  it("未指定なら1", () => {
+    expect(parseEventPage(new URLSearchParams())).toBe(1);
+  });
+
+  it("数値として読めない値なら1", () => {
+    expect(parseEventPage(new URLSearchParams("page=abc"))).toBe(1);
+    expect(parseEventPage(new URLSearchParams("page="))).toBe(1);
+  });
+
+  it("範囲の検証はしない（paginateEvents の担当）", () => {
+    expect(parseEventPage(new URLSearchParams("page=-1"))).toBe(-1);
+    expect(parseEventPage(new URLSearchParams("page=999"))).toBe(999);
+  });
+});
+
+describe("buildEventsQuery", () => {
+  it("既定値だけなら空文字（/events を正規URLに保つ）", () => {
+    expect(buildEventsQuery(DEFAULT_EVENT_FILTERS)).toBe("");
+    expect(buildEventsQuery({})).toBe("");
+  });
+
+  it("既定値の項目を落とす", () => {
+    expect(buildEventsQuery({ date: "all", type: "stage", building: "all", keyword: "" })).toBe(
+      "type=stage"
+    );
+  });
+
+  it("複数の絞り込みを保つ", () => {
+    // パーセントエンコードの綴りではなく、値と並び順を検証する
+    const query = buildEventsQuery({
+      date: "day1",
+      type: "stage",
+      building: "7号館",
+      keyword: "軽音",
+    });
+
+    expect([...new URLSearchParams(query)]).toEqual([
+      ["date", "day1"],
+      ["type", "stage"],
+      ["building", "7号館"],
+      ["keyword", "軽音"],
+    ]);
+  });
+
+  it("1ページ目はクエリに出さない", () => {
+    expect(buildEventsQuery({ type: "stage" }, 1)).toBe("type=stage");
+    expect(buildEventsQuery({ type: "stage" }, 2)).toBe("type=stage&page=2");
+  });
+
+  it("往復してもフィルターが変わらない", () => {
+    const filters: FilterParams = {
+      date: "both",
+      type: "room",
+      building: "体育館",
+      keyword: "展示",
+    };
+
+    expect(parseEventFilters(new URLSearchParams(buildEventsQuery(filters, 3)))).toEqual(filters);
+    expect(parseEventPage(new URLSearchParams(buildEventsQuery(filters, 3)))).toBe(3);
+  });
+});
+
+describe("eventsHref", () => {
+  it("既定値だけならクエリを付けない", () => {
+    expect(eventsHref(DEFAULT_EVENT_FILTERS)).toBe("/events");
+  });
+
+  it("クエリがあれば ? を付ける", () => {
+    expect(eventsHref({ type: "stage" }, 2)).toBe("/events?type=stage&page=2");
   });
 });

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -11,6 +11,101 @@ export interface FilterParams {
 }
 
 /**
+ * 1ページあたりの表示件数
+ *
+ * `EventsContent` のローカル定数でしたが、`src/app/events/page.tsx` が
+ * <Suspense> の fallback 用に同じ区切りで1ページ目を切り出す必要があるため引き上げました。
+ * 2箇所で別々に持つと、fallback と本描画で表示件数がずれます。
+ */
+export const EVENTS_PER_PAGE = 12;
+
+/**
+ * 絞り込み無しの状態
+ *
+ * クエリを持たない `/events` に相当します。`page.tsx` の fallback はこの状態を描きます。
+ */
+export const DEFAULT_EVENT_FILTERS: FilterParams = {
+  date: "all",
+  type: "all",
+  building: "all",
+  keyword: "",
+};
+
+/**
+ * `URLSearchParams` の読み取りに必要な最小限の形
+ *
+ * `next/navigation` の `ReadonlyURLSearchParams` と `URLSearchParams` の両方が満たします。
+ * このモジュールを Next.js に依存させないための構造的型で、ユニットテストからは
+ * 素の `URLSearchParams` を渡せます。
+ */
+interface SearchParamsLike {
+  get(name: string): string | null;
+}
+
+/**
+ * URL のクエリからフィルターパラメータを組み立てる
+ * @param params 読み取り元のクエリ
+ * @returns 未指定の項目を既定値（"all" / 空文字）で埋めたフィルターパラメータ
+ */
+export function parseEventFilters(params: SearchParamsLike): FilterParams {
+  return {
+    date: (params.get("date") as EventDate | "all") || "all",
+    type: (params.get("type") as EventType | "all") || "all",
+    building: params.get("building") || "all",
+    keyword: params.get("keyword") || "",
+  };
+}
+
+/**
+ * URL のクエリから現在のページ番号を取り出す
+ * @param params 読み取り元のクエリ
+ * @returns ページ番号。数値として読めない場合は 1
+ *
+ * 範囲の検証はしません。負値や範囲外は `paginateEvents` が空配列として扱います（#162）。
+ */
+export function parseEventPage(params: SearchParamsLike): number {
+  return Number(params.get("page")) || 1;
+}
+
+/**
+ * フィルターパラメータから URL のクエリ文字列を組み立てる
+ * @param filters フィルターパラメータ
+ * @param page ページ番号（1 のときは付けない）
+ * @returns クエリ文字列。既定値だけなら空文字
+ *
+ * 既定値（"all" / 空文字 / page === 1）は落とします。`/events` の正規URLを
+ * クエリ無しに保ち、`?date=all&type=all` のような同一内容の別URLを作らないためです。
+ *
+ * **現在URLの未知パラメータは引き継ぎません。** 以前は `searchParams.toString()` を
+ * 起点にしていましたが、`/events` が読むパラメータは date / type / building / keyword / page の
+ * 5つだけであり（`parseEventFilters` と `parseEventPage` が読む全て）、props から組み直しても
+ * 等価です。この形にしたのは、`EventFilters` と `Pagination` から `useSearchParams()` を
+ * 外すためです（理由は `EventsView` のコメントを参照）。
+ */
+export function buildEventsQuery(filters: FilterParams, page = 1): string {
+  const params = new URLSearchParams();
+
+  if (filters.date && filters.date !== "all") params.set("date", filters.date);
+  if (filters.type && filters.type !== "all") params.set("type", filters.type);
+  if (filters.building && filters.building !== "all") params.set("building", filters.building);
+  if (filters.keyword) params.set("keyword", filters.keyword);
+  if (page > 1) params.set("page", String(page));
+
+  return params.toString();
+}
+
+/**
+ * フィルターパラメータから `/events` の URL を組み立てる
+ * @param filters フィルターパラメータ
+ * @param page ページ番号（1 のときは付けない）
+ * @returns 例: `/events?type=stage`。既定値だけなら `/events`
+ */
+export function eventsHref(filters: FilterParams, page = 1): string {
+  const query = buildEventsQuery(filters, page);
+  return query ? `/events?${query}` : "/events";
+}
+
+/**
  * 企画をフィルタリング
  * @param events 企画の配列
  * @param filters フィルターパラメータ
@@ -58,7 +153,7 @@ export function filterEvents(events: Event[], filters: FilterParams): Event[] {
  * @returns ページネーションされた企画の配列。存在しないページなら空配列
  *
  * **1未満のページを弾くこと。** `page` は URL のクエリから検証なしに入ります
- * （`EventsContent` の `Number(searchParams.get("page")) || 1`。`-1` は truthy なので
+ * （`parseEventPage` の `Number(params.get("page")) || 1`。`-1` は truthy なので
  * `|| 1` を素通りします）。始点が負のまま `slice()` へ渡すと末尾からの相対位置として
  * 解釈され、**空でも1ページ目でもない「別のページ」が返ります**（#162）。
  *


### PR DESCRIPTION
Closes #156

## 何が起きていたか

`/events` は、ヒーローから下のページ本体が静的HTMLに一切含まれていませんでした。
`EventsContent` が `useSearchParams()` を使うのに `<Suspense>` 境界が無く、bailout を
`src/app/events/loading.tsx` が捕まえていたためです。

> [!NOTE]
> Issue 本文は「ルート直下の `src/app/loading.tsx` が捕まえる」と書いていますが、
> `/events` を捕まえていたのは **`src/app/events/loading.tsx`** でした（実測）。
> 範囲が同じなので結果は変わりません。

## なぜ `<Suspense>` を足すだけでは足りないのか

**bailout は「境界の内側をクライアント描画へ落とす」ものであって、内側をサーバー描画へ
戻すものではありません。** 境界を足すと落ちる範囲が縮むだけで、企画カードのリンクは
0本のままです。Issue の「確認方法」2つ目（`href="/events/xxx"` が1本以上）は、
対応方針どおりの最小修正では達成できません。

`<Suspense>` の **fallback はサーバーで描かれ、静的HTMLに出力されます**。そこで fallback を
プレースホルダではなく「クエリ無しで着地したときの完成形」＝未フィルタ1ページ目にしました。

```
<Suspense fallback={<EventsView ...既定値... />}>   ← 静的HTMLに出る
  <EventsContent initialEvents={events} />          ← "use client" / useSearchParams
    └ <EventsView ... />                            ← 同じコンポーネント
</Suspense>
```

そのために `useSearchParams()` の読み手を `EventsContent` の1箇所へ集約し、表示ツリーを
`EventsView` として切り出しました。**`EventFilters` と `Pagination` の props 化は
リファクタのついでではなく必須条件です。** fallback の中で `useSearchParams()` を呼ぶと、
それ以上落ちる先が無く fallback 自身が bailout します。

包む範囲は `EventsContent` だけです。著名人企画への導線（上部リンク・下部セクション）は
Server Component なので境界の外に残し、静的HTMLへ残しています。

## 実測

`NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build` → `.next/server/app/events.html`

| 確認項目 | 境界なし | このPR |
| --- | --- | --- |
| `data-page-hero="true"` | 0 | **1** |
| `data-page-sheet="true"` | 0 | **1** |
| `href="/events/xxx"`（重複除く） | 0 | **11** |
| `href="/special/xxx"`（重複除く） | 0 | **1** |
| `件の企画が見つかりました` | 0 | **1** |
| `BAILOUT_TO_CLIENT_SIDE_RENDERING` の位置 | `events/loading.tsx` の境界 | 追加した境界の内側 |
| HTML raw | 81,635 B | 184,964 B |
| gzip -9 | 15,429 B | 24,898 B |
| brotli -q11 | 12,780 B | **16,990 B（+4.2KB）** |

raw では2.3倍ですが、HTMLと flight ペイロードに同じマークアップが2度出るため圧縮がよく効きます。
**転送量の増加は +4.2KB です。**

### 差し替えの体感（`pnpm start` + Playwright / クリーンなコンテキスト）

fallback は hydrate されず、破棄されて本描画に差し替わります。

| 着地URL | fallback → 本描画 | CLS |
| --- | --- | --- |
| `/events` | 388ms | 0 |
| `/events?type=stage`（18→15件） | 384ms | 0 |
| `/events?type=room`（カード12枚→1枚） | 413ms | 0 |
| `/events?page=2` | 379ms | 0 |

クエリ付きで着地すると、差し替わるまでの数百ミリ秒は未フィルタの一覧が見えます。
CLS が 0 なのは、スクロール位置0の視界をヒーローが占めており、折り返しより下の高さ変化が
可視要素をずらさないためです（`?type=room` は文書高が 4,283 → 2,708px と縮んでも 0）。

## 判定方法の注意（ドキュメントにも記録）

- **`grep -c` を使わない。** HTML は改行の無い1行なので常に 0 か 1 を返します
- **`data-page-hero` だけで検索しない。** 落ちている状態でも3件ヒットします。RSC の flight
  ペイロードに `\"data-page-hero\":true` という別の綴りで入っているためです。
  描画されたHTMLに出るのは `data-page-hero="true"` のほう

## 検証

- [x] `pnpm lint` / `pnpm format:check` / `pnpm type-check`
- [x] `pnpm test`（~~131件~~ **116件**）— `buildEventsQuery` / `parseEventFilters` / `parseEventPage` を追加
      （マージ後のレビューで訂正。base `7d1b09e` が 104 件、本PRで +12 件。ローカル実行と CI Static Checks のログの両方で 116 を確認）
- [x] `NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build` → 上表の grep
- [x] `pnpm start` 実機でフィルタ・ページ送り・リセットの動作、CLS 実測
- [ ] `pnpm test:e2e` — ローカルでは別プロセスの `next dev` が `.next/dev/lock` を握っており
      起動できませんでした。`/timetable` は無改変のため CI の Layout E2E に委ねます

## 範囲外（別Issueを立てます）

キーワード検索で `filterEvents` が `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`
を投げ、エラー境界が発動します。**このPRとは無関係の既存バグです**（`filterEvents` は無改変）。
microCMS の実データは全18件で `building` が未入力、3件は `organizer` / `description` も未入力で、
`normalizeEvent()` が `...rawEvent` を素通しさせているため `Event` 型の必須宣言が実データで
守られていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiPEd66ahPoYS3NRNcHWx2

