### PR TITLE
feat: refine event detail and sponsor presentation

### DIFF
--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { getEventById, getEventsList } from "@/lib/events";
 import { SPECIAL_VISIBLE } from "@/data/site";
 import { EventDetail } from "@/components/events/EventDetail";
@@ -138,10 +139,10 @@ export default async function EventPage({ params }: EventPageProps) {
         }}
       />
 
-      <div className="min-h-screen bg-gradient-to-b from-primary-dark to-primary">
+      <div className="min-h-screen bg-gradient-to-b from-white via-primary-50 to-secondary pb-20">
         {/* パンくずリスト */}
-        <nav className="border-b border-gray-200/20 bg-white/10 py-4" aria-label="パンくずリスト">
-          <div className="container mx-auto px-4">
+        <nav className="event-detail-entrance-nav bg-white py-4" aria-label="パンくずリスト">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <ol className="flex flex-wrap items-center gap-2 text-sm text-gray-900/80">
               <li>
                 <Link href="/" className="hover:text-gray-900 hover:underline">
@@ -185,7 +186,10 @@ export default async function EventPage({ params }: EventPageProps) {
                   />
                 </svg>
               </li>
-              <li className="font-semibold text-gray-900" aria-current="page">
+              <li
+                className="min-w-0 max-w-[45vw] truncate font-semibold text-gray-900 sm:max-w-md"
+                aria-current="page"
+              >
                 {event.title}
               </li>
             </ol>
@@ -193,35 +197,25 @@ export default async function EventPage({ params }: EventPageProps) {
         </nav>
 
         {/* メインコンテンツ */}
-        <div className="container mx-auto px-4 py-12">
-          <div className="mx-auto max-w-4xl">
+        <main className="event-detail-entrance-sheet relative z-10 mx-4 mt-0 overflow-hidden rounded-[2rem] bg-white shadow-[0_-4px_20px_rgba(0,0,0,0.08)] sm:mx-6 md:-mt-6 lg:mx-8">
+          <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8 lg:py-16">
             <EventDetail event={event} />
-          </div>
 
-          {/* 戻るボタン */}
-          <div className="mx-auto mt-12 max-w-4xl">
-            <Link
-              href="/events"
-              className="inline-flex items-center gap-2 text-primary-700 hover:underline"
-            >
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
+            {/* 戻るボタン */}
+            <div className="mt-14 border-t border-gray-200 pt-8">
+              <Link
+                href="/events"
+                className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-700 underline-offset-4 transition-colors hover:text-primary-900 hover:underline focus-visible:outline-3 focus-visible:outline-offset-4 focus-visible:outline-primary-600"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
+                <ArrowLeft
+                  className="h-4 w-4 transition-transform group-hover:-translate-x-0.5"
+                  aria-hidden="true"
                 />
-              </svg>
-              <span>企画一覧に戻る</span>
-            </Link>
+                <span>企画一覧に戻る</span>
+              </Link>
+            </div>
           </div>
-        </div>
+        </main>
 
         {/* 関連企画 */}
         <RelatedEvents currentEvent={event} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -434,6 +434,76 @@ body {
   }
 }
 
+/* ===== Event detail entrance ===== */
+
+/*
+ * イベント詳細の初期表示だけに使う控えめな入場。
+ * 画像は LCP 候補のため透明化せず、移動・拡大率だけを変える。
+ */
+.event-detail-entrance-nav {
+  animation: event-detail-nav-in 0.42s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.event-detail-entrance-sheet {
+  animation: event-detail-sheet-in 0.62s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.event-detail-entrance-media {
+  animation: event-detail-media-in 0.76s cubic-bezier(0.2, 0.8, 0.2, 1) 0.12s both;
+}
+
+.event-detail-entrance-copy {
+  animation: event-detail-content-in 0.52s cubic-bezier(0.2, 0.8, 0.2, 1) 0.18s both;
+}
+
+.event-detail-entrance-section {
+  animation: event-detail-content-in 0.52s cubic-bezier(0.2, 0.8, 0.2, 1) 0.3s both;
+}
+
+.event-detail-entrance-related {
+  animation: event-detail-content-in 0.62s cubic-bezier(0.2, 0.8, 0.2, 1) 0.42s both;
+}
+
+@keyframes event-detail-nav-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes event-detail-sheet-in {
+  from {
+    transform: translateY(14px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes event-detail-media-in {
+  from {
+    transform: scale(0.985);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
+@keyframes event-detail-content-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Blob浮遊アニメーション（2パターンでずらして有機的な動きに） */
 @keyframes blob-drift-1 {
   0%,
@@ -654,6 +724,14 @@ body {
     animation: none !important;
   }
   .page-transition-wrapper.page-enter-history {
+    animation: none !important;
+  }
+  .event-detail-entrance-nav,
+  .event-detail-entrance-sheet,
+  .event-detail-entrance-media,
+  .event-detail-entrance-copy,
+  .event-detail-entrance-section,
+  .event-detail-entrance-related {
     animation: none !important;
   }
   [class*="animate-blob"] {

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -6,8 +6,22 @@ import { CircleImage } from "@/components/ui/CircleImage";
 
 interface EventCardProps {
   event: Event;
-  variant?: "default" | "featured";
+  variant?: "default" | "featured" | "compact";
 }
+
+const dateLabels: Record<Event["date"], string> = {
+  day1: "1日目",
+  day2: "2日目",
+  both: "両日",
+  other: "その他",
+};
+
+const typeLabels: Record<Event["type"], string> = {
+  room: "教室",
+  stage: "ステージ",
+  special: "スペシャル",
+  other: "その他",
+};
 
 /**
  * 企画カードコンポーネント
@@ -16,41 +30,59 @@ interface EventCardProps {
 export function EventCard({ event, variant = "default" }: EventCardProps) {
   // 著名人企画は専用LP（/special/[id]）が正規URL。/events/[id] は生成されない
   const href = event.type === "special" ? `/special/${event.id}` : `/events/${event.id}`;
+  const isCompact = variant === "compact";
+  const venue = [event.building, event.place].filter(Boolean).join(" ") || "会場未定";
 
   return (
     <Link href={href} className="group block h-full">
-      <article className="h-full overflow-hidden rounded-2xl border border-gray-200/20 bg-white/10 transition-colors hover:border-gray-200/40">
+      <article
+        className={`h-full overflow-hidden border border-gray-200 bg-white transition-[border-color,box-shadow] hover:border-primary-300 hover:shadow-sm ${isCompact ? "flex items-start rounded-lg" : "rounded-xl"}`}
+      >
         {/* 円形サムネイル */}
         {event.thumbnail && (
-          <div className="flex justify-center p-6">
-            <CircleImage src={event.thumbnail.url} alt={event.title} size="xl" />
+          <div className={isCompact ? "shrink-0 p-4" : "flex justify-center p-6"}>
+            <CircleImage
+              src={event.thumbnail.url}
+              alt={event.title}
+              size={isCompact ? "md" : "xl"}
+            />
           </div>
         )}
 
-        <div className="flex flex-1 flex-col p-6 pt-0">
+        <div
+          className={`flex min-w-0 flex-1 flex-col ${isCompact && event.thumbnail ? "p-4 pl-0" : isCompact ? "p-4" : "p-6 pt-0"}`}
+        >
           {/* バッジ */}
           <div className="mb-3 flex flex-wrap gap-2">
-            <Badge variant={event.date} label={event.date} />
-            <Badge variant={event.type} label={event.type} />
+            <Badge variant={event.date} label={dateLabels[event.date]} tone="soft" />
+            <Badge variant={event.type} label={typeLabels[event.type]} tone="soft" />
           </div>
 
           {/* タイトル */}
           <h3
             className={`mb-2 line-clamp-2 font-bold text-gray-900 ${
-              variant === "featured" ? "text-xl" : "text-lg"
+              variant === "featured" ? "text-xl" : isCompact ? "text-base" : "text-lg"
             }`}
           >
             {event.title}
           </h3>
 
           {/* 主催団体 */}
-          <p className="mb-3 text-sm font-semibold text-primary-700">{event.organizer}</p>
+          <p
+            className={`font-semibold text-primary-700 ${isCompact ? "mb-2 text-xs" : "mb-3 text-sm"}`}
+          >
+            {event.organizer}
+          </p>
 
           {/* 説明文 */}
-          <p className="mb-4 line-clamp-3 text-sm text-gray-900/80">{event.description}</p>
+          <p
+            className={`${isCompact ? "mb-2 line-clamp-2 text-xs leading-5" : "mb-4 line-clamp-3 text-sm"} text-gray-900/80`}
+          >
+            {event.description}
+          </p>
 
           {/* メタ情報 */}
-          <div className="flex flex-wrap gap-x-4 gap-y-2 border-t border-gray-200/20 pt-3 text-xs text-gray-900/60">
+          <div className="flex flex-wrap gap-x-4 gap-y-2 border-t border-gray-200 pt-3 text-xs text-gray-600">
             {/* 場所 */}
             <div className="flex items-center gap-1">
               <svg
@@ -67,9 +99,7 @@ export function EventCard({ event, variant = "default" }: EventCardProps) {
                   d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
                 />
               </svg>
-              <span>
-                {event.building} {event.place}
-              </span>
+              <span>{venue}</span>
             </div>
 
             {/* 開催時間 */}

--- a/src/components/events/EventDetail.tsx
+++ b/src/components/events/EventDetail.tsx
@@ -7,171 +7,186 @@ interface EventDetailProps {
   event: Event;
 }
 
+interface EventFactProps {
+  label: string;
+  value: string;
+}
+
+const dateLabels: Record<Event["date"], string> = {
+  day1: "1日目（10月31日）",
+  day2: "2日目（11月1日）",
+  both: "両日開催",
+  other: "その他",
+};
+
+const dateBadgeLabels: Record<Event["date"], string> = {
+  day1: "1日目",
+  day2: "2日目",
+  both: "両日",
+  other: "その他",
+};
+
+const typeLabels: Record<Event["type"], string> = {
+  room: "教室企画",
+  stage: "ステージ企画",
+  special: "スペシャル企画",
+  other: "その他",
+};
+
+const SQUARE_IMAGE_TOLERANCE = 0.05;
+
+function EventFact({ label, value }: EventFactProps) {
+  return (
+    <div className="border-t border-gray-200 pt-4 first:border-t-0 first:pt-0 sm:border-t-0 sm:pt-0">
+      <dt className="text-sm font-semibold text-gray-600">{label}</dt>
+      <dd className="mt-1 text-base font-semibold leading-relaxed text-gray-900">{value}</dd>
+    </div>
+  );
+}
+
 /**
  * 企画詳細コンポーネント
- * 企画の詳細情報を表示
+ * 企画の主役である画像・タイトルと、来場に必要な情報を優先して表示する。
  */
 export function EventDetail({ event }: EventDetailProps) {
+  const venue = [event.building, event.place].filter(Boolean).join(" ") || "会場未定";
+  const thumbnailWidth = event.thumbnail?.width ?? 0;
+  const thumbnailHeight = event.thumbnail?.height ?? 0;
+  const isIconThumbnail =
+    event.thumbnail !== undefined &&
+    thumbnailWidth > 0 &&
+    thumbnailHeight > 0 &&
+    Math.abs(thumbnailWidth - thumbnailHeight) / Math.max(thumbnailWidth, thumbnailHeight) <=
+      SQUARE_IMAGE_TOLERANCE;
+  const time =
+    event.startTime && event.endTime
+      ? `${event.startTime} 〜 ${event.endTime}`
+      : event.startTime
+        ? `${event.startTime}〜`
+        : "時間未定";
+
   return (
-    <div className="space-y-8">
-      {/* サムネイル画像 */}
-      {event.thumbnail && (
-        <div className="relative aspect-video w-full overflow-hidden rounded-lg border border-gray-200/20">
-          <Image
-            src={event.thumbnail.url}
-            alt={event.title}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 1000px"
-            priority
-          />
-        </div>
-      )}
-
-      {/* タイトルセクション */}
-      <div>
-        {/* バッジ */}
-        <div className="mb-4 flex flex-wrap gap-2">
-          <Badge variant={event.date} label={event.date} />
-          <Badge variant={event.type} label={event.type} />
-        </div>
-
-        {/* タイトル */}
-        <h1 className="mb-3 text-3xl font-bold text-gray-900 md:text-4xl">{event.title}</h1>
-
-        {/* 主催団体 */}
-        <p className="text-xl font-semibold text-primary-700">{event.organizer}</p>
-      </div>
-
-      {/* メタ情報 */}
-      <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6">
-        <h2 className="mb-4 text-lg font-bold text-gray-900">開催情報</h2>
-        <dl className="space-y-3">
-          {/* 開催日 */}
-          <div className="flex items-start gap-3">
-            <dt className="flex items-center gap-2 text-sm font-semibold text-gray-900/90">
-              <svg
-                className="h-5 w-5 text-primary-700"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+    <article className="mx-auto max-w-5xl space-y-12">
+      {/* 企画ヘッダー */}
+      <div
+        className={`grid ${isIconThumbnail ? "gap-4" : "gap-8"} lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.75fr)] lg:items-center lg:gap-12`}
+      >
+        {event.thumbnail && (
+          <div
+            className={`event-detail-entrance-media relative overflow-hidden ${isIconThumbnail ? "flex h-72 items-center justify-center rounded-2xl sm:h-80 lg:h-96" : "-mx-4 -mt-10 aspect-[4/3] max-h-[32rem] rounded-t-2xl rounded-b-none sm:-mx-6 lg:-mx-8 lg:-mt-16"}`}
+          >
+            {isIconThumbnail ? (
+              <div className="relative h-36 w-36 sm:h-44 sm:w-44 lg:h-52 lg:w-52">
+                <Image
+                  src={event.thumbnail.url}
+                  alt={event.title}
+                  fill
+                  className="object-contain"
+                  sizes="(max-width: 1024px) 60vw, 33vw"
+                  priority
                 />
-              </svg>
-              開催日
-            </dt>
-            <dd className="text-sm text-gray-900">
-              {event.date === "day1" && "1日目（10月31日）"}
-              {event.date === "day2" && "2日目（11月1日）"}
-              {event.date === "both" && "両日開催"}
-              {event.date === "other" && "その他"}
-            </dd>
+              </div>
+            ) : (
+              <Image
+                src={event.thumbnail.url}
+                alt={event.title}
+                fill
+                className="object-cover object-center"
+                sizes="(max-width: 1024px) 100vw, 55vw"
+                priority
+              />
+            )}
+          </div>
+        )}
+
+        <header
+          className={`event-detail-entrance-copy ${event.thumbnail ? "lg:py-6" : "lg:col-span-2 lg:py-6"}`}
+        >
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={event.date} label={dateBadgeLabels[event.date]} tone="soft" />
+            <Badge
+              variant={event.type}
+              label={
+                event.type === "room"
+                  ? "教室"
+                  : event.type === "stage"
+                    ? "ステージ"
+                    : typeLabels[event.type]
+              }
+              tone="soft"
+            />
           </div>
 
-          {/* 開催時間 */}
-          {event.startTime && event.endTime && (
-            <div className="flex items-start gap-3">
-              <dt className="flex items-center gap-2 text-sm font-semibold text-gray-900/90">
-                <svg
-                  className="h-5 w-5 text-primary-700"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                開催時間
-              </dt>
-              <dd className="text-sm text-gray-900">
-                {event.startTime} 〜 {event.endTime}
-              </dd>
+          <h1 className="mt-5 text-3xl font-bold leading-[1.2] tracking-tight text-gray-900 sm:text-5xl">
+            {event.title}
+          </h1>
+
+          {event.organizer && (
+            <div className="mt-6 border-t border-gray-200 pt-5">
+              <p className="text-xs font-semibold text-gray-600">主催</p>
+              <p className="mt-1 text-base font-semibold text-gray-900">{event.organizer}</p>
             </div>
           )}
-
-          {/* 場所 */}
-          <div className="flex items-start gap-3">
-            <dt className="flex items-center gap-2 text-sm font-semibold text-gray-900/90">
-              <svg
-                className="h-5 w-5 text-primary-700"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-              </svg>
-              場所
-            </dt>
-            <dd className="text-sm text-gray-900">
-              {event.building} {event.place}
-            </dd>
-          </div>
-
-          {/* 企画種別 */}
-          <div className="flex items-start gap-3">
-            <dt className="flex items-center gap-2 text-sm font-semibold text-gray-900/90">
-              <svg
-                className="h-5 w-5 text-primary-700"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
-                />
-              </svg>
-              種別
-            </dt>
-            <dd className="text-sm text-gray-900">
-              {event.type === "room" && "教室企画"}
-              {event.type === "stage" && "ステージ企画"}
-              {event.type === "special" && "スペシャル企画"}
-              {event.type === "other" && "その他"}
-            </dd>
-          </div>
-        </dl>
+        </header>
       </div>
+
+      {/* 開催情報 */}
+      <section
+        aria-labelledby="event-information-heading"
+        className="event-detail-entrance-section border-y border-gray-200 py-8"
+      >
+        <h2
+          id="event-information-heading"
+          className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl"
+        >
+          開催情報
+        </h2>
+
+        <dl className="mt-6 grid gap-x-8 gap-y-6 sm:grid-cols-2">
+          <EventFact label="開催日" value={dateLabels[event.date]} />
+          <EventFact label="開催時間" value={time} />
+          <EventFact label="会場" value={venue} />
+          <EventFact label="企画種別" value={typeLabels[event.type]} />
+        </dl>
+      </section>
 
       {/* 企画概要 */}
-      <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6">
-        <h2 className="mb-4 text-lg font-bold text-gray-900">企画概要</h2>
-        <p className="whitespace-pre-wrap text-gray-900/90">{event.description}</p>
-      </div>
+      <section
+        aria-labelledby="event-summary-heading"
+        className="event-detail-entrance-section max-w-3xl"
+      >
+        <h2
+          id="event-summary-heading"
+          className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl"
+        >
+          企画概要
+        </h2>
+        <p className="mt-5 whitespace-pre-wrap text-base leading-8 text-gray-700">
+          {event.description}
+        </p>
+      </section>
 
       {/* 詳細説明（リッチテキスト） */}
       {event.content && (
-        <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6">
-          <h2 className="mb-4 text-lg font-bold text-gray-900">詳細</h2>
+        <section
+          aria-labelledby="event-content-heading"
+          className="event-detail-entrance-section max-w-3xl border-t border-gray-200 pt-8"
+        >
+          <h2
+            id="event-content-heading"
+            className="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl"
+          >
+            詳細
+          </h2>
           <div
-            className="prose prose-invert max-w-none"
+            className="mt-5 text-base leading-8 text-gray-700 [&_a]:font-semibold [&_a]:text-primary-700 [&_a]:underline [&_h2]:mt-8 [&_h2]:font-serif [&_h2]:text-2xl [&_h2]:font-bold [&_h3]:mt-6 [&_h3]:font-serif [&_h3]:text-xl [&_h3]:font-bold [&_li]:ml-5 [&_li]:list-disc [&_ol]:space-y-2 [&_p+p]:mt-4 [&_ul]:space-y-2"
             dangerouslySetInnerHTML={{ __html: event.content }}
           />
-        </div>
+        </section>
       )}
 
       {/* SNSリンク */}
       <SNSLinks sns={event.sns} />
-    </div>
+    </article>
   );
 }

--- a/src/components/events/EventGrid.tsx
+++ b/src/components/events/EventGrid.tsx
@@ -3,7 +3,7 @@ import { EventCard } from "./EventCard";
 
 interface EventGridProps {
   events: Event[];
-  variant?: "default" | "featured";
+  variant?: "default" | "featured" | "compact";
 }
 
 /**
@@ -36,7 +36,9 @@ export function EventGrid({ events, variant = "default" }: EventGridProps) {
   }
 
   return (
-    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      className={`grid ${variant === "compact" ? "gap-4" : "gap-6"} sm:grid-cols-2 lg:grid-cols-3`}
+    >
       {events.map((event) => (
         <EventCard key={event.id} event={event} variant={variant} />
       ))}

--- a/src/components/events/RelatedEvents.tsx
+++ b/src/components/events/RelatedEvents.tsx
@@ -1,5 +1,7 @@
 import type { Event } from "@/types/events";
 import { getEventsList } from "@/lib/events";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import { EventGrid } from "./EventGrid";
 
 interface RelatedEventsProps {
@@ -44,10 +46,26 @@ export async function RelatedEvents({ currentEvent }: RelatedEventsProps) {
   }
 
   return (
-    <section className="border-t border-gray-200/20 bg-secondary py-16">
-      <div className="container mx-auto px-4">
-        <h2 className="mb-8 text-center text-3xl font-bold text-gray-900">関連企画</h2>
-        <EventGrid events={relatedEvents} />
+    <section className="event-detail-entrance-related bg-transparent px-4 py-16 sm:py-20">
+      <div className="mx-auto max-w-7xl sm:px-2 lg:px-4">
+        <div className="mb-8 flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-end">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
+              関連企画
+            </h2>
+          </div>
+          <Link
+            href="/events"
+            className="group inline-flex items-center gap-2 text-sm font-semibold text-primary-700 underline-offset-4 transition-colors hover:text-primary-900 hover:underline focus-visible:outline-3 focus-visible:outline-offset-4 focus-visible:outline-primary-600"
+          >
+            企画一覧を見る
+            <ArrowRight
+              className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+              aria-hidden="true"
+            />
+          </Link>
+        </div>
+        <EventGrid events={relatedEvents} variant="compact" />
       </div>
     </section>
   );

--- a/src/components/events/SNSLinks.tsx
+++ b/src/components/events/SNSLinks.tsx
@@ -14,16 +14,18 @@ export function SNSLinks({ sns }: SNSLinksProps) {
   }
 
   return (
-    <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6">
-      <h3 className="mb-4 text-lg font-bold text-gray-900">SNS・関連リンク</h3>
-      <div className="flex flex-wrap gap-3">
+    <section className="border-t border-gray-200 pt-10" aria-labelledby="event-links-heading">
+      <h3 id="event-links-heading" className="text-2xl font-bold tracking-tight text-gray-900">
+        SNS・関連リンク
+      </h3>
+      <div className="mt-5 flex flex-wrap gap-x-6 gap-y-3">
         {/* Twitter */}
         {sns.twitter && (
           <a
             href={sns.twitter}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-lg border border-gray-200/30 bg-white/10 px-4 py-2 text-sm font-medium text-gray-900 transition-all hover:border-[#1DA1F2] hover:bg-[#1DA1F2] hover:text-gray-900"
+            className="inline-flex min-h-11 items-center gap-2 border-b border-gray-300 py-2 text-sm font-semibold text-gray-700 transition-colors hover:border-[#1DA1F2] hover:text-gray-900 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-[#1DA1F2]"
             aria-label="Twitterで開く"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -39,7 +41,7 @@ export function SNSLinks({ sns }: SNSLinksProps) {
             href={sns.instagram}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-lg border border-gray-200/30 bg-white/10 px-4 py-2 text-sm font-medium text-gray-900 transition-all hover:border-[#E4405F] hover:bg-[#E4405F] hover:text-gray-900"
+            className="inline-flex min-h-11 items-center gap-2 border-b border-gray-300 py-2 text-sm font-semibold text-gray-700 transition-colors hover:border-[#E4405F] hover:text-gray-900 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-[#E4405F]"
             aria-label="Instagramで開く"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -59,7 +61,7 @@ export function SNSLinks({ sns }: SNSLinksProps) {
             href={sns.website}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-lg border border-gray-200/30 bg-white/10 px-4 py-2 text-sm font-medium text-gray-900 transition-all hover:border-primary-light hover:bg-primary-200"
+            className="inline-flex min-h-11 items-center gap-2 border-b border-gray-300 py-2 text-sm font-semibold text-gray-700 transition-colors hover:border-primary-600 hover:text-primary-700 focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
             aria-label="公式サイトを開く"
           >
             <svg
@@ -80,6 +82,6 @@ export function SNSLinks({ sns }: SNSLinksProps) {
           </a>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/components/home/SponsorBanner.tsx
+++ b/src/components/home/SponsorBanner.tsx
@@ -15,7 +15,7 @@ export async function SponsorBanner() {
   return (
     <section className="deferred-section deferred-section--sponsors overflow-hidden bg-white py-16">
       <div className="container mx-auto px-4">
-        <h2 className="mb-10 text-center text-3xl font-bold">協賛企業</h2>
+        <h2 className="mb-10 text-center text-3xl font-bold">協賛・協力</h2>
       </div>
       <SponsorLogoLoopLoader sponsors={sponsors} />
     </section>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -11,9 +11,12 @@ export type BadgeVariant =
   | "stage"
   | "special";
 
+export type BadgeTone = "default" | "soft";
+
 export interface BadgeProps {
   variant: BadgeVariant;
   label: string;
+  tone?: BadgeTone;
   className?: string;
 }
 
@@ -21,7 +24,7 @@ export interface BadgeProps {
  * バッジコンポーネント
  * カテゴリやタイプを視覚的に表示
  */
-export function Badge({ variant, label, className }: BadgeProps) {
+export function Badge({ variant, label, tone = "default", className }: BadgeProps) {
   const baseStyles = "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold";
 
   const variantStyles: Record<BadgeVariant, string> = {
@@ -36,5 +39,7 @@ export function Badge({ variant, label, className }: BadgeProps) {
     special: "bg-pink-500 text-gray-900",
   };
 
-  return <span className={cn(baseStyles, variantStyles[variant], className)}>{label}</span>;
+  const colorStyles = tone === "soft" ? "bg-primary-100 text-primary-700" : variantStyles[variant];
+
+  return <span className={cn(baseStyles, colorStyles, className)}>{label}</span>;
 }


### PR DESCRIPTION
## Summary
- イベント詳細ページをシンプルでクリーンなレイアウトに整理
- 画像の縦横比に応じてアイコン表示とヘッダー表示を切り替え
- 初期表示アニメーション、薄紫タグ、トップページの「協賛・協力」表記を追加

## Verification
- mise exec node@24.13.0 -- pnpm type-check
- mise exec node@24.13.0 -- pnpm lint（既存warning 7件、errorなし）
- mise exec node@24.13.0 -- pnpm test（144 tests passed）
- git diff --check
- localhost:3004でトップページとイベント詳細3ページを確認