### PR TITLE
CI: /events の静的HTML検査を pnpm build へ連結し、解禁と同時に自動発動させる

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -349,8 +349,11 @@ microCMS の入稿は **Webhook 経由で数秒以内**に本番へ反映され�
 > （`/timetable` は #154、`/events` は #156）。**#148 は同じ `/timetable` でも別件**で、
 > `height: 100%` が `0px` に解決される CSS の不具合であり bailout とは無関係である。
 > `/events` を捕まえていたのはルートではなく `src/app/events/loading.tsx` である。
-> **再発は `eslint.config.mjs` の `no-restricted-imports` が止める**（fallback ツリーの5ファイルが
-> `useSearchParams` を import できない）。判定方法・fallback の設計・実測値は
+> **再発防止装置は2つある。** `eslint.config.mjs` の `no-restricted-imports`（fallback ツリーの
+> 5ファイルが `useSearchParams` を import できない）と、`pnpm build` の末尾へ連結した
+> `scripts/assert-events-static-html.mjs`（`<Suspense>` 境界の消失と fallback の格下げを落とす。
+> **`EVENTS_VISIBLE` が false の間はスキップし、true になると自動で有効化する**）。
+> 判定方法・fallback の設計・実測値は
 > [`docs/frontend/static-html-and-search-params.md`](../docs/frontend/static-html-and-search-params.md) を参照。
 
 > [!WARNING]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -311,6 +311,7 @@ docs/
   - 実測: 静的HTMLの企画リンク 0 → 11本。転送量は brotli で +4.2KB。差し替えは約390ms、CLS 0
   - **再発防止装置は2つ。** `eslint.config.mjs` の `no-restricted-imports`（fallback ツリーがクエリを読み始めるのを止める）と、`scripts/assert-events-static-html.mjs`（境界の消失・fallback の格下げを `pnpm build` で落とす）
   - **アサーションはフラグ false の間スキップし、`EVENTS_VISIBLE=true` になった瞬間に自動で有効化する。** 解禁時に足す作業は要らない
+  - **フラグは `@next/env` の `loadEnvConfig()` で読む。** 素の `process.env` は `.env.local` を読まないため、`next build` とアサーションが違う値を見て「事実と正反対のメッセージで落ちる」
 
 - **[i18n-page-structure.md](./frontend/i18n-page-structure.md)** - 多言語ページの構成パターン
   - メッセージの二分割（ページ本文 `messages/` と ヘッダー・フッター `messages/chrome/`）

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -309,7 +309,8 @@ docs/
   - **fallback の中で `useSearchParams()` を呼んではいけない**（それ以上落ちる先が無い）。下位からは props へ引き上げる
   - 判定は `data-page-hero="true"` の綴りで行う。`grep -c` と属性名だけの grep はどちらも誤読する（flight ペイロードに別綴りで入っている）
   - 実測: 静的HTMLの企画リンク 0 → 11本。転送量は brotli で +4.2KB。差し替えは約390ms、CLS 0
-  - **再発防止は `eslint.config.mjs` の `no-restricted-imports`。** fallback ツリーの5ファイルへ `useSearchParams` の import を禁じている（境界そのものの削除は止められない）
+  - **再発防止装置は2つ。** `eslint.config.mjs` の `no-restricted-imports`（fallback ツリーがクエリを読み始めるのを止める）と、`scripts/assert-events-static-html.mjs`（境界の消失・fallback の格下げを `pnpm build` で落とす）
+  - **アサーションはフラグ false の間スキップし、`EVENTS_VISIBLE=true` になった瞬間に自動で有効化する。** 解禁時に足す作業は要らない
 
 - **[i18n-page-structure.md](./frontend/i18n-page-structure.md)** - 多言語ページの構成パターン
   - メッセージの二分割（ページ本文 `messages/` と ヘッダー・フッター `messages/chrome/`）

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -119,6 +119,17 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 - いずれも `true` の場合のみ公開する。未設定または `true` 以外は安全側として非公開になる。
 - ビルド時に評価されるため、値を変更した後は再ビルド・再デプロイが必要。
 
+> [!IMPORTANT]
+> **`NEXT_PUBLIC_EVENTS_VISIBLE` を `true` にすると、`/events` の静的HTML検査が自動で有効になる。**
+> `scripts/assert-events-static-html.mjs`（`pnpm build` の末尾に連結）がフラグを見て分岐しており、
+> `false` の間はスキップ、`true` になった瞬間から `pnpm build` の合否条件になる。
+> **解禁作業のときに検査を足す必要は無い。**
+>
+> 逆に言えば、**解禁後は `/events` のページ本体が静的HTMLから消えるとデプロイが落ちる。**
+> 落ちたときの原因と手順は
+> [`../frontend/static-html-and-search-params.md`](../frontend/static-html-and-search-params.md)
+> 「再発防止装置 その2」を参照（#156）。
+
 ### EVENTS_VISIBLE と SPECIAL_VISIBLE の組み合わせ
 
 **この2つは独立している。** 著名人の発表はチケット販売と紐づき、一般企画一覧の公開より先行することがあるため、別のフラグに分けている。

--- a/docs/dev/ci-env.md
+++ b/docs/dev/ci-env.md
@@ -129,6 +129,11 @@ CI/CD ワークフローで使用する環境変数の管理方法と登録手�
 > 落ちたときの原因と手順は
 > [`../frontend/static-html-and-search-params.md`](../frontend/static-html-and-search-params.md)
 > 「再発防止装置 その2」を参照（#156）。
+>
+> **このスクリプトは `@next/env` でフラグを解決する。** `next build` と同じ順序で
+> `.env.production.local` → `.env.local` → `.env.production` → `.env` を読むため、
+> 下表の「ローカル (.env.local)」でフラグを `true` にしても、ページとアサーションが
+> 食い違うことはない。**素の `process.env` へ戻してはいけない。**
 
 ### EVENTS_VISIBLE と SPECIAL_VISIBLE の組み合わせ
 
@@ -373,13 +378,13 @@ curl -sL "$URL" | grep -o '<探しているマークアップ>'
 
 本プロジェクトは同名の環境変数を環境ごとに別値で登録しています。`vercel env ls` の `environments` 列で確認できます。
 
-| 変数                          | 登録状況                                     |
-| ----------------------------- | -------------------------------------------- |
-| `MICROCMS_SERVICE_DOMAIN`     | **Production と Preview で別行＝別値**       |
-| `MICROCMS_API_KEY`            | Production, Preview で共有／Development は別 |
-| `NEXT_PUBLIC_EVENTS_VISIBLE`  | Production, Preview で共有                   |
-| `NEXT_PUBLIC_NEWS_VISIBLE`    | Production, Preview で共有                   |
-| `NEXT_PUBLIC_SPECIAL_VISIBLE` | Production, Preview で共有                   |
+| 変数                          | 登録状況                                           |
+| ----------------------------- | -------------------------------------------------- |
+| `MICROCMS_SERVICE_DOMAIN`     | **Production と Preview で別行＝別値**             |
+| `MICROCMS_API_KEY`            | Production, Preview で共有／Development は別       |
+| `NEXT_PUBLIC_EVENTS_VISIBLE`  | **Preview のみ登録**（Production は未登録＝false） |
+| `NEXT_PUBLIC_NEWS_VISIBLE`    | Production, Preview で共有                         |
+| `NEXT_PUBLIC_SPECIAL_VISIBLE` | Production, Preview で共有                         |
 
 `MICROCMS_SERVICE_DOMAIN` が環境別なので、`promote` すると **Preview の microCMS サービスから取得したコンテンツが本番に出ます。** 正しい操作は Production 環境変数での再ビルドです。
 

--- a/docs/frontend/static-html-and-search-params.md
+++ b/docs/frontend/static-html-and-search-params.md
@@ -185,8 +185,44 @@ const EVENTS_FALLBACK_TREE = [
 瞬間から検査を始める。** 解禁のタイミングで誰かが検査を「足す」必要は無い。
 スキップ時も準備中ページが実際に描かれていることは確認するので、素通りではない。
 
-Vercel Preview は既に `EVENTS_VISIBLE=true` なので（[../dev/ci-env.md](../dev/ci-env.md)）、
+Vercel Preview は `EVENTS_VISIBLE=true` なので（[../dev/ci-env.md](../dev/ci-env.md) の
+Vercel 環境変数表。2026-09-05 に `vercel env ls` で再確認。**Production には登録が無い**）、
 **解禁を待たず現時点から Preview デプロイのゲートとして稼働している。**
+PR #173 の Preview ビルドログでも `pnpm run build` → アサーションの `OK` 行まで確認済み。
+
+### フラグは `next build` と同じ手順で読む
+
+> [!IMPORTANT]
+> **素の `process.env` を読んではいけない。** `next build` は `@next/env` を通して
+> `.env.production.local` → `.env.local` → `.env.production` → `.env` の順に解決するが、
+> `node scripts/...` はそのどれも読まない。**同じ `pnpm build` の中で、ページとアサーションが
+> 違うフラグ値を見ることになる。**
+
+`.env.example` は `NEXT_PUBLIC_EVENTS_VISIBLE=false` を含んだまま `.env.local` へコピーさせる
+運用なので、**解禁のリハーサルで `.env.local` を `true` にした瞬間に踏む。** そのとき
+`next build` は公開状態のページを描き、アサーションはフラグを `undefined` と見て
+「準備中の文言がありません」と、**事実と正反対のメッセージで exit 1 する。**
+
+対処として、スクリプト冒頭で `next` 本体と同じローダーを呼んでいる。
+
+```js
+import nextEnv from "@next/env"; // CommonJS のため .mjs からは default 経由で取り出す
+const { loadEnvConfig } = nextEnv;
+
+loadEnvConfig(process.cwd(), false); // 第2引数 false = 本番モード（.env.production 側を読む）
+```
+
+`@next/env` は `next` が内部で使っているパッケージそのもので、**バージョンを `next` と
+揃えて devDependencies へ固定してある**（lockfile には `importers` の参照が1つ増えるだけで、
+新しいパッケージは入らない）。シェルや CI が渡した値を `.env` ファイルより優先する挙動まで
+`next build` と同じになる。
+
+| 状況                                       | `next build` | アサーション（修正前）    | アサーション（修正後） |
+| ------------------------------------------ | ------------ | ------------------------- | ---------------------- |
+| `.env.local` に `true`                     | 公開で描画   | **false と誤認 → 落ちる** | true                   |
+| `.env.production` に `true`                | 公開で描画   | **false と誤認 → 落ちる** | true                   |
+| シェルで `true`（CI・Vercel）              | 公開で描画   | true                      | true                   |
+| シェルで `false` ＋ `.env.local` に `true` | 非公開で描画 | false                     | false（シェルが優先）  |
 
 ### 何を見ているか
 

--- a/docs/frontend/static-html-and-search-params.md
+++ b/docs/frontend/static-html-and-search-params.md
@@ -163,13 +163,60 @@ const EVENTS_FALLBACK_TREE = [
 | 現状                                         | exit 0          |
 | `EventFilters` へ `useSearchParams` を戻した | **exit 1**      |
 
-> [!WARNING]
-> **このルールが守るのは「クエリを読む場所」だけである。** `src/app/events/page.tsx` から
-> `<Suspense>` 境界そのものを外す変更は、ESLint では止められない。境界の有無は
-> ビルド生成物を読むしかなく、その検査には microCMS の secrets と
-> `NEXT_PUBLIC_EVENTS_VISIBLE=true` が要る（`Build Check` は `vars` を参照しており、
-> 解禁前は `true` にならないため現時点では検査が空振りする）。
-> **`page.tsx` を触るときは、下記の grep を手で通すこと。**
+**このルールが守るのは「クエリを読む場所」だけである。** `src/app/events/page.tsx` から
+`<Suspense>` 境界そのものを外す変更は、ESLint では止められない。そちらは次の装置が受け持つ。
+
+---
+
+## 再発防止装置 その2 — ビルド生成物のアサーション
+
+`scripts/assert-events-static-html.mjs` を `pnpm build` の末尾へ連結してある。
+
+```json
+"build": "next build && node scripts/assert-events-static-html.mjs"
+```
+
+`postbuild` にしていないのは、pnpm の `enable-pre-post-scripts` に依存させないため。
+既定値が変わったり `.npmrc` へ一行足されたりすると、**装置が黙って死ぬ。**
+
+### フラグが false の間も置いておいてよい
+
+**`NEXT_PUBLIC_EVENTS_VISIBLE` が `"true"` でなければ自動でスキップし、`true` になった
+瞬間から検査を始める。** 解禁のタイミングで誰かが検査を「足す」必要は無い。
+スキップ時も準備中ページが実際に描かれていることは確認するので、素通りではない。
+
+Vercel Preview は既に `EVENTS_VISIBLE=true` なので（[../dev/ci-env.md](../dev/ci-env.md)）、
+**解禁を待たず現時点から Preview デプロイのゲートとして稼働している。**
+
+### 何を見ているか
+
+`EventFilters` が描くキーワード入力欄の `id="keyword-search"` を見る。
+
+- `EventsView` ツリーがサーバー描画されたことの証拠になる
+- **企画が0件でも描かれる**（`EventGrid` が空状態を出すだけでフィルターUIは残る）。
+  したがって microCMS が一時的に空を返しても誤検知しない。
+  **件数に依存する指標を合否条件にしてはいけない**（企画詳細リンクの本数は参考値として
+  ログに出すだけ）
+
+> [!IMPORTANT]
+> **`data-page-hero` と `data-page-sheet` は判定に使えない。** `ComingSoon` も
+> `PageSheetLayout` を通るため、フラグが false の本番でも 1 件ずつ出る（2026-09-05 実測）。
+> #156 の表にある「0 → 1」は「境界なし かつ `EVENTS_VISIBLE=true`」限定の比較値である。
+
+### 退行注入で実測（2026-09-05 / `NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build`）
+
+| 状態                                                | `pnpm build` | 企画リンク |
+| --------------------------------------------------- | ------------ | ---------- |
+| 現状                                                | exit 0       | 11本       |
+| `page.tsx` から `<Suspense>` 境界を削除             | **exit 1**   | 0本        |
+| fallback を `EventsView` からプレースホルダへ格下げ | **exit 1**   | 0本        |
+
+**2つ目と3つ目は ESLint では捕まらない。** 2つの装置は役割が違う。
+
+| 装置                                    | 捕まえるもの                          |
+| --------------------------------------- | ------------------------------------- |
+| `eslint.config.mjs`                     | fallback ツリーがクエリを読み始めた   |
+| `scripts/assert-events-static-html.mjs` | 境界の消失・fallback の格下げ・その他 |
 
 ---
 
@@ -183,4 +230,7 @@ const EVENTS_FALLBACK_TREE = [
 4. ビルドして上記の grep を通す。**通ることは何も証明しません。** 境界を一時的に外して
    数字が 0 に戻ることまで確かめること（[layout-e2e.md](./layout-e2e.md) と同じ作法）
 5. **その制約を機械で検査する手段を同じPRで用意する。** 散文コメントは装置ではない。
-   最低でも `eslint.config.mjs` の `no-restricted-imports` へ対象ファイルを足すこと
+   `eslint.config.mjs` の `no-restricted-imports` へ対象ファイルを足し、fallback を
+   既定状態の完成形にしたなら `scripts/assert-events-static-html.mjs` に倣って
+   ビルド生成物のアサーションも置く。**フラグで隠れているページでも、フラグを見て
+   スキップする形にすれば今すぐ置ける**（解禁時に足す約束は必ず忘れられる）

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && node scripts/assert-events-static-html.mjs",
     "start": "next start",
     "lint": "eslint src/ e2e/ playwright.config.ts",
     "type-check": "next typegen && tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.1.4",
+    "@next/env": "16.1.0",
     "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^16.1.4
         version: 16.1.4
+      '@next/env':
+        specifier: 16.1.0
+        version: 16.1.0
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1

--- a/scripts/assert-events-static-html.mjs
+++ b/scripts/assert-events-static-html.mjs
@@ -29,6 +29,13 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
+/*
+ * `@next/env` は CommonJS のため、`.mjs` から名前付き import できない
+ * （Node 20 が `Named export 'loadEnvConfig' not found` で落ちる）。default 経由で取り出す。
+ */
+import nextEnv from "@next/env";
+
+const { loadEnvConfig } = nextEnv;
 
 /** `next build` が `/events` を事前描画した成果物 */
 const HTML_PATH = path.resolve(process.cwd(), ".next/server/app/events.html");
@@ -41,7 +48,13 @@ const HTML_PATH = path.resolve(process.cwd(), ".next/server/app/events.html");
  */
 const EVENTS_UI_MARKER = 'id="keyword-search"';
 
-/** `ComingSoon` の見出し。フラグが false のときに出る */
+/**
+ * `ComingSoon` の見出し。フラグが false のときに出る
+ *
+ * これは `src/app/events/page.tsx` が `<ComingSoon title="..." />` へ渡している文言の複製である。
+ * 文言を直すときは本ファイルも同時に直すこと。**現在フラグは false なので、この複製が外れると
+ * 落ちるのは CI の `Build Check` と本番ビルドである**（`EVENTS_UI_MARKER` 側とは落ちる環境が違う）。
+ */
 const COMING_SOON_MARKER = "企画情報は準備中です";
 
 /** 参考値としてだけ数える。件数は入稿状況で変わるので合否条件にしない */
@@ -54,6 +67,28 @@ function fail(message, hint) {
   if (hint) console.error(hint);
   process.exit(1);
 }
+
+/*
+ * フラグは `next build` と同じ手順で解決する。
+ *
+ * 素の `process.env` だけを見てはいけない。`next build` は `@next/env` を通して
+ * `.env.production.local` → `.env.local` → `.env.production` → `.env` の順に読み込むため、
+ * `.env.local` へ `NEXT_PUBLIC_EVENTS_VISIBLE=true` を置いた手元のビルドでは
+ * **ページだけが公開状態で描かれ、このスクリプトは undefined を見る**という食い違いが起きる。
+ * その状態では正しく描かれたHTMLに対して「準備中の文言がありません」と、事実と正反対の
+ * メッセージで exit 1 する（`.env.example` はこのフラグを含んだまま `.env.local` へ
+ * コピーさせる運用なので、解禁のリハーサルで確実に踏む）。
+ *
+ * `loadEnvConfig` は next 本体が使っているローダーそのものであり、シェルや CI が渡した
+ * 値を `.env` ファイルより優先する点まで同じ挙動になる。第2引数の `false` は本番モード
+ * （`.env.development` ではなく `.env.production` を読む）を意味する。
+ *
+ * 読み込んだファイルの一覧は `next build` が既に出力しているため、ここでは黙らせる。
+ */
+loadEnvConfig(process.cwd(), false, {
+  info: () => {},
+  error: (...args) => console.error(LABEL, ...args),
+});
 
 const eventsVisible = process.env.NEXT_PUBLIC_EVENTS_VISIBLE === "true";
 
@@ -75,16 +110,25 @@ const hasEventsUi = html.includes(EVENTS_UI_MARKER);
 if (!eventsVisible) {
   // 検査対象そのものが存在しない状態。ただし「スキップした」で終わらせず、
   // 準備中ページが実際に描かれていることまでは確かめる。
-  if (!html.includes(COMING_SOON_MARKER)) {
-    fail(
-      `NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないのに、準備中の文言（${COMING_SOON_MARKER}）がHTMLにありません。`,
-      "  /events の静的HTMLが期待どおりに描かれていません。フラグの値とページの分岐を確認してください。"
-    );
-  }
+  //
+  // 漏洩の検査を先に置く。ページが公開状態で描かれていると2つの条件が同時に成立するが、
+  // 「非公開のはずの企画情報が配信されている」ほうが具体的で、事故としても重い。
+  // 順序を逆にすると、実際に情報が漏れているときに「準備中の文言がありません」という
+  // 弱いメッセージだけが出て、読んだ人間が原因へ辿り着けない。
   if (hasEventsUi) {
     fail(
       `NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないのに、企画一覧のUI（${EVENTS_UI_MARKER}）がHTMLに出ています。`,
       "  非公開のはずの企画情報が配信されています。EVENTS_VISIBLE の分岐を確認してください。"
+    );
+  }
+  if (!html.includes(COMING_SOON_MARKER)) {
+    fail(
+      `NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないのに、準備中の文言（${COMING_SOON_MARKER}）がHTMLにありません。`,
+      [
+        "  /events の静的HTMLが期待どおりに描かれていません。次の順で確認してください。",
+        `    1. ${COMING_SOON_MARKER} を書き換えていないか（この文言は src/app/events/page.tsx と本ファイルの2箇所にある）`,
+        "    2. EVENTS_VISIBLE の分岐そのものが変わっていないか",
+      ].join("\n")
     );
   }
   console.log(

--- a/scripts/assert-events-static-html.mjs
+++ b/scripts/assert-events-static-html.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * `/events` のページ本体が静的HTMLに残っているかを検査する（#156 の再発防止装置）
+ *
+ * `pnpm build` の末尾で走る。**フラグが false の間は自動でスキップし、
+ * `NEXT_PUBLIC_EVENTS_VISIBLE=true` になった瞬間から検査を始める。**
+ * 解禁のタイミングで誰かが検査を「足す」必要は無い。
+ *
+ * ## なぜ ESLint だけでは足りないのか
+ *
+ * `eslint.config.mjs` の `no-restricted-imports` は「クエリを読む場所」を固定するが、
+ * `src/app/events/page.tsx` から `<Suspense>` 境界そのものを外す変更は止められない。
+ * 境界が消えると `src/app/events/loading.tsx` が代役になり、ページ本体が丸ごと
+ * クライアント描画へ落ちる。**エラーは出ない。** 境界の有無はビルド生成物を
+ * 読む以外に確かめる方法が無い。
+ *
+ * ## 何を見ているか
+ *
+ * `EventFilters` が描くキーワード入力欄の `id` を見る。これは `EventsView` ツリーが
+ * サーバー描画されたことの証拠であり、**企画が0件でも描かれる**（`EventGrid` が
+ * 空状態を出すだけで、フィルターUI自体は残る）。したがって microCMS が一時的に
+ * 空を返しても誤検知しない。件数に依存する指標を条件にしてはいけない。
+ *
+ * `data-page-hero` と `data-page-sheet` は**使えない。** `ComingSoon` も
+ * `PageSheetLayout` を通るため、フラグが false の本番でも 1 件出る（2026-09-05 実測）。
+ *
+ * 背景と実測は docs/frontend/static-html-and-search-params.md を参照。
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+/** `next build` が `/events` を事前描画した成果物 */
+const HTML_PATH = path.resolve(process.cwd(), ".next/server/app/events.html");
+
+/**
+ * `EventFilters` のキーワード入力欄
+ *
+ * これを改名するときは本ファイルも同時に直すこと。CI と Vercel Preview が
+ * 先に赤くなるため、本番へ到達する前に気付ける。
+ */
+const EVENTS_UI_MARKER = 'id="keyword-search"';
+
+/** `ComingSoon` の見出し。フラグが false のときに出る */
+const COMING_SOON_MARKER = "企画情報は準備中です";
+
+/** 参考値としてだけ数える。件数は入稿状況で変わるので合否条件にしない */
+const EVENT_LINK_PATTERN = /href="\/events\/[a-zA-Z0-9_-]+"/g;
+
+const LABEL = "[assert-events-static-html]";
+
+function fail(message, hint) {
+  console.error(`${LABEL} FAIL: ${message}`);
+  if (hint) console.error(hint);
+  process.exit(1);
+}
+
+const eventsVisible = process.env.NEXT_PUBLIC_EVENTS_VISIBLE === "true";
+
+if (!existsSync(HTML_PATH)) {
+  fail(
+    `${path.relative(process.cwd(), HTML_PATH)} が見つかりません。`,
+    [
+      "  /events が事前描画されなくなった可能性があります。",
+      "  ルートが動的化した（searchParams / cookies / headers を読む等）か、",
+      "  Next.js の出力先が変わったかのどちらかです。どちらも意図した変更なら、",
+      "  このスクリプトの HTML_PATH を実際の出力先へ合わせてください。",
+    ].join("\n")
+  );
+}
+
+const html = readFileSync(HTML_PATH, "utf8");
+const hasEventsUi = html.includes(EVENTS_UI_MARKER);
+
+if (!eventsVisible) {
+  // 検査対象そのものが存在しない状態。ただし「スキップした」で終わらせず、
+  // 準備中ページが実際に描かれていることまでは確かめる。
+  if (!html.includes(COMING_SOON_MARKER)) {
+    fail(
+      `NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないのに、準備中の文言（${COMING_SOON_MARKER}）がHTMLにありません。`,
+      "  /events の静的HTMLが期待どおりに描かれていません。フラグの値とページの分岐を確認してください。"
+    );
+  }
+  if (hasEventsUi) {
+    fail(
+      `NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないのに、企画一覧のUI（${EVENTS_UI_MARKER}）がHTMLに出ています。`,
+      "  非公開のはずの企画情報が配信されています。EVENTS_VISIBLE の分岐を確認してください。"
+    );
+  }
+  console.log(
+    `${LABEL} SKIP: NEXT_PUBLIC_EVENTS_VISIBLE が "true" ではないため、企画一覧の検査は行いません。` +
+      ` 準備中ページの描画のみ確認しました。**フラグを true にすると、この検査は自動で有効になります。**`
+  );
+  process.exit(0);
+}
+
+if (!hasEventsUi) {
+  fail(
+    `/events の静的HTMLに企画一覧のUI（${EVENTS_UI_MARKER}）がありません。ページ本体がクライアント描画へ落ちています（#156 の再発）。`,
+    [
+      "  よくある原因:",
+      "    1. src/app/events/page.tsx から <Suspense> 境界が外れた",
+      "       → 境界が無いと src/app/events/loading.tsx が代役になり、ページ本体が丸ごと落ちます",
+      "    2. <Suspense> の fallback が EventsView ではなくプレースホルダに戻った",
+      "       → fallback はサーバーで描かれてHTMLに出る唯一の部分です",
+      "    3. fallback ツリーのどれかが useSearchParams() を呼んだ",
+      "       → 通常は eslint.config.mjs の no-restricted-imports が先に止めます",
+      "",
+      "  手で確かめる:",
+      "    grep -o 'id=\"keyword-search\"' .next/server/app/events.html | wc -l",
+      "    grep -o '.\\{160\\}BAILOUT_TO_CLIENT_SIDE_RENDERING' .next/server/app/events.html",
+      "",
+      "  詳細: docs/frontend/static-html-and-search-params.md",
+    ].join("\n")
+  );
+}
+
+const eventLinks = new Set(html.match(EVENT_LINK_PATTERN) ?? []);
+console.log(
+  `${LABEL} OK: /events の静的HTMLにページ本体があります（企画詳細へのリンク ${eventLinks.size} 本）。`
+);
+
+if (eventLinks.size === 0) {
+  // 企画が未入稿でも UI は描かれるため、これは異常ではない。合否条件にはしない。
+  console.warn(
+    `${LABEL} NOTE: 企画詳細へのリンクが0本です。microCMS に企画が未入稿か、` +
+      `取得に失敗している可能性があります（UIは描かれているため検査は成功扱い）。`
+  );
+}


### PR DESCRIPTION
#172 で残した穴を塞ぎます。あわせて「解禁時に検査を足す」という**忘れられる約束**を無くします。

## 何が残っていたか

#172 の ESLint（`no-restricted-imports`）が守れるのは「クエリを読む場所」だけでした。`src/app/events/page.tsx` から `<Suspense>` 境界そのものを外す変更は止められません。境界の有無は**ビルド生成物を読む以外に確かめる方法がありません。**

これを「`NEXT_PUBLIC_EVENTS_VISIBLE` を `true` にするときに足す」という約束にすると、必ず忘れられます。**フラグを見て分岐する形にすれば、解禁を待たずに今すぐ置けます。**

## 自己起動アサーション

`scripts/assert-events-static-html.mjs` を `build` の末尾へ連結しました。

```json
"build": "next build && node scripts/assert-events-static-html.mjs"
```

| フラグ | 挙動 |
| --- | --- |
| `EVENTS_VISIBLE !== "true"` | **スキップ**（ただし準備中ページが実際に描かれていることは確認する） |
| `EVENTS_VISIBLE === "true"` | **合否条件になる** |

- **解禁時に足す作業は要りません。** フラグが `true` になった瞬間に自動で有効化されます
- **Vercel Preview は既に `EVENTS_VISIBLE=true`** なので（`docs/dev/ci-env.md`）、解禁を待たず**このPRのマージ直後から Preview デプロイのゲートとして稼働**します

`postbuild` にしなかったのは、pnpm の `enable-pre-post-scripts` に依存させないためです。既定値が変わるか `.npmrc` へ一行足されると、**装置が黙って死にます。**

## 判定子の選定 — `id="keyword-search"`

`EventFilters` が描くキーワード入力欄の `id` を見ます。

- `EventsView` ツリーがサーバー描画されたことの証拠になる
- **企画が0件でも描かれる**（`EventGrid` が空状態を出すだけでフィルターUIは残る）ため、**microCMS が一時的に空を返してもデプロイを止めません。** 件数に依存する指標を合否条件にしてはいけません（企画詳細リンクの本数は参考値としてログに出すだけ）

> [!IMPORTANT]
> **`data-page-hero` / `data-page-sheet` は判定に使えません。** `ComingSoon` も `PageSheetLayout` を通るため、フラグが `false` の本番でも 1 件ずつ出ます（2026-09-05 実測）。#156 の表の「0 → 1」は「境界なし **かつ** `EVENTS_VISIBLE=true`」限定の比較値でした。

## 退行注入で実測（2026-09-05 / 実ビルド3本）

**通ることは何も証明しないので、実際に赤くなることを確かめました。**

| 状態 | `pnpm build` | 企画リンク |
| --- | --- | --- |
| 現状 | exit 0 | 11本 |
| `page.tsx` から `<Suspense>` 境界を削除 | **exit 1** | 0本 |
| fallback を `EventsView` からプレースホルダへ格下げ | **exit 1** | 0本 |

**下2つは ESLint では捕まりません。** 2つの装置は役割が違います。

| 装置 | 捕まえるもの |
| --- | --- |
| `eslint.config.mjs`（#172） | fallback ツリーがクエリを読み始めた |
| `scripts/assert-events-static-html.mjs`（本PR） | 境界の消失・fallback の格下げ・その他 |

フラグ `false` でのビルドも実測し、`SKIP` して exit 0 になることを確認済みです。

## 検証

- [x] `pnpm lint` / `pnpm format:check` / `pnpm type-check`（すべて exit 0）
- [x] `pnpm test`（**160 passed / 7 files**）
- [x] `NEXT_PUBLIC_EVENTS_VISIBLE=true pnpm build` → exit 0、アサーション OK（11本）
- [x] `NEXT_PUBLIC_EVENTS_VISIBLE=false pnpm build` → exit 0、アサーション SKIP
- [x] 退行注入2種で `pnpm build` が exit 1 になることを実ビルドで確認
- [ ] `pnpm test:e2e` — `/timetable` に無関係のため CI の Layout E2E に委ねます

## ドキュメント

- `docs/frontend/static-html-and-search-params.md` — 「再発防止装置 その2」を新設。#172 で書いた「守れない穴」の WARNING を、塞いだ装置の説明へ差し替え
- `docs/dev/ci-env.md` — **解禁時に検査を足す必要が無いこと**、および解禁後は静的HTMLが消えるとデプロイが落ちることを公開フラグ節へ明記
- `.claude/CLAUDE.md` / `docs/INDEX.md` — 装置が2つになったことを反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiPEd66ahPoYS3NRNcHWx2