### PR TITLE
FIX: UI監査の残り4件に対応する（#183 B/C/D/E）

### DIFF
--- a/src/app/[locale]/about/privacy/page.tsx
+++ b/src/app/[locale]/about/privacy/page.tsx
@@ -191,7 +191,7 @@ export default async function PrivacyPolicyPage({
           <p className="mb-4 text-gray-700">{privacyPolicyConfig.contact.description}</p>
           <Link
             href={privacyPolicyConfig.contact.url}
-            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 font-semibold text-white transition-all hover:bg-primary-500 hover:shadow-lg"
+            className="inline-flex items-center gap-2 rounded-lg bg-primary px-6 py-3 font-semibold text-white transition-[color,background-color,border-color,box-shadow] hover:bg-primary-500 hover:shadow-lg"
           >
             <Mail className="h-5 w-5" />
             <span>{t("toContactForm")}</span>

--- a/src/app/[locale]/info/contact/ContactForm.tsx
+++ b/src/app/[locale]/info/contact/ContactForm.tsx
@@ -219,7 +219,7 @@ export function ContactForm() {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-4 font-semibold text-white transition-all hover:bg-primary-500 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-6 py-4 font-semibold text-white transition-[color,background-color,border-color,box-shadow] hover:bg-primary-500 hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting ? (
               <>

--- a/src/app/[locale]/info/faq/FAQContent.tsx
+++ b/src/app/[locale]/info/faq/FAQContent.tsx
@@ -247,7 +247,7 @@ function FilterButton({ label, isActive, onClick, count }: FilterButtonProps) {
       type="button"
       onClick={onClick}
       aria-pressed={isActive}
-      className={`rounded-full border px-5 py-2 text-sm font-semibold transition-all focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
+      className={`rounded-full border px-5 py-2 text-sm font-semibold transition-colors focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
         isActive
           ? "border-primary-600 bg-primary-600 text-white shadow-md"
           : "border-gray-200 bg-gray-50 text-gray-700 hoverable:hover:border-gray-400 hoverable:hover:bg-white"

--- a/src/app/[locale]/info/guide/page.tsx
+++ b/src/app/[locale]/info/guide/page.tsx
@@ -200,7 +200,7 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
               return (
                 <div
                   key={item.id}
-                  className={`rounded-xl border-l-4 ${style.border} ${style.bg} p-5 shadow-sm transition-all hover:shadow-md`}
+                  className={`rounded-xl border-l-4 ${style.border} ${style.bg} p-5 shadow-sm transition-shadow hover:shadow-md`}
                 >
                   <div className="mb-2 flex items-center gap-2">
                     <span aria-hidden="true" className="text-2xl">
@@ -441,7 +441,7 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
           <div className="grid gap-4 md:grid-cols-3">
             <Link
               href="/access"
-              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:border-primary-300 hover:shadow-md"
+              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-[color,background-color,border-color,box-shadow] hover:border-primary-300 hover:shadow-md"
             >
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-50 transition-colors group-hover:bg-primary-100">
                 <Map className="h-5 w-5 text-primary" />
@@ -453,7 +453,7 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
             </Link>
             <Link
               href="/info/contact"
-              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:border-primary-300 hover:shadow-md"
+              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-[color,background-color,border-color,box-shadow] hover:border-primary-300 hover:shadow-md"
             >
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-50 transition-colors group-hover:bg-primary-100">
                 <Mail className="h-5 w-5 text-primary" />
@@ -465,7 +465,7 @@ export default async function GuidePage({ params }: { params: Promise<{ locale: 
             </Link>
             <Link
               href="/info/faq"
-              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-all hover:border-primary-300 hover:shadow-md"
+              className="group flex items-center gap-3 rounded-xl border border-gray-200 bg-white p-4 transition-[color,background-color,border-color,box-shadow] hover:border-primary-300 hover:shadow-md"
             >
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-50 transition-colors group-hover:bg-primary-100">
                 <HelpCircle className="h-5 w-5 text-primary" />

--- a/src/app/about/sponsors/page.tsx
+++ b/src/app/about/sponsors/page.tsx
@@ -89,7 +89,7 @@ interface SponsorCardProps {
 
 function SponsorCard({ sponsor }: SponsorCardProps) {
   const CardContent = (
-    <div className="group h-full overflow-hidden rounded-lg border border-gray-200/20 bg-white/10 shadow-sm transition-all hover:border-gray-200 hover:shadow-lg">
+    <div className="group h-full overflow-hidden rounded-lg border border-gray-200/20 bg-white/10 shadow-sm transition-[color,background-color,border-color,box-shadow] hover:border-gray-200 hover:shadow-lg">
       {/* ロゴ */}
       {sponsor.image ? (
         <div className="relative aspect-video w-full overflow-hidden bg-white/10">

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -14,9 +14,11 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-24">
+    <div className="container mx-auto flex min-h-screen flex-col items-center justify-center px-4 py-24">
       <h2 className="mb-4 text-2xl font-bold">エラーが発生しました</h2>
-      <p className="mb-8 text-gray-900/80">申し訳ございません。問題が発生しました。</p>
+      <p className="mb-8 text-gray-900/80">
+        ページの読み込みに失敗しました。しばらく経ってから再度お試しください。
+      </p>
       <button
         onClick={() => reset()}
         className="rounded-md bg-white px-4 py-2 text-primary hover:opacity-80"

--- a/src/app/events/[id]/error.tsx
+++ b/src/app/events/[id]/error.tsx
@@ -75,7 +75,7 @@ export default function EventDetailError({
             </Button>
             <Link
               href="/events"
-              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-all duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
+              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
             >
               企画一覧へ戻る
             </Link>

--- a/src/app/events/[id]/not-found.tsx
+++ b/src/app/events/[id]/not-found.tsx
@@ -45,13 +45,13 @@ export default function EventDetailNotFound() {
           <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
             <Link
               href="/events"
-              className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-base font-semibold text-primary shadow-md transition-all duration-200 hover:bg-white/90 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
+              className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-base font-semibold text-primary shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hover:bg-white/90 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
             >
               企画一覧へ戻る
             </Link>
             <Link
               href="/"
-              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-all duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
+              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
             >
               トップページへ戻る
             </Link>

--- a/src/app/events/error.tsx
+++ b/src/app/events/error.tsx
@@ -57,7 +57,7 @@ export default function EventsError({
             </Button>
             <Link
               href="/"
-              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-all duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
+              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
             >
               トップページへ戻る
             </Link>

--- a/src/app/info/NewsContent.tsx
+++ b/src/app/info/NewsContent.tsx
@@ -91,7 +91,7 @@ function FilterButton({ label, isActive, onClick, count }: FilterButtonProps) {
   return (
     <button
       onClick={onClick}
-      className={`rounded-full border px-5 py-2 text-sm font-semibold transition-all focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
+      className={`rounded-full border px-5 py-2 text-sm font-semibold transition-colors focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
         isActive
           ? "border-primary-600 bg-primary-600 text-white shadow-md"
           : "border-gray-200 bg-gray-50 text-gray-700 hoverable:hover:border-gray-400 hoverable:hover:bg-white"
@@ -119,7 +119,7 @@ function NewsCard({ news }: NewsCardProps) {
 
   return (
     <Link href={`/info/${news.id}`} className="group block h-full">
-      <article className="h-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-all hoverable:hover:border-gray-400 hoverable:hover:shadow-lg">
+      <article className="h-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-[color,background-color,border-color,box-shadow] hoverable:hover:border-gray-400 hoverable:hover:shadow-lg">
         {/* サムネイル */}
         {news.thumbnail && (
           <div className="relative aspect-video w-full overflow-hidden">

--- a/src/app/info/pamphlet/page.tsx
+++ b/src/app/info/pamphlet/page.tsx
@@ -119,7 +119,7 @@ export default function PamphletPage() {
                         <a
                           href={pamphlet.fileUrl}
                           download
-                          className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-semibold text-primary transition-all hover:bg-white/90 hover:shadow-lg md:w-auto"
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-semibold text-primary transition-[color,background-color,border-color,box-shadow] hover:bg-white/90 hover:shadow-lg md:w-auto"
                         >
                           <Download className="h-5 w-5" />
                           <span>PDFをダウンロード</span>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-24">
+    <div className="container mx-auto flex min-h-screen flex-col items-center justify-center px-4 py-24">
       <h2 className="mb-4 text-2xl font-bold">404 - ページが見つかりません</h2>
       <p className="mb-8 text-gray-900/80">お探しのページは見つかりませんでした。</p>
       <Link href="/" className="rounded-md bg-white px-4 py-2 text-primary hover:opacity-80">

--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -65,7 +65,7 @@ export function EventFilters({ filters }: EventFiltersProps) {
               <button
                 key={option.value}
                 onClick={() => handleFilterChange({ date: option.value })}
-                className={`rounded-full border px-4 py-2 text-sm font-medium transition-all focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
                   currentDate === option.value
                     ? "border-primary-600 bg-primary-600 text-white"
                     : "border-gray-200 bg-gray-50 text-gray-700 hoverable:hover:border-gray-400 hoverable:hover:bg-white"
@@ -86,7 +86,7 @@ export function EventFilters({ filters }: EventFiltersProps) {
               <button
                 key={option.value}
                 onClick={() => handleFilterChange({ type: option.value })}
-                className={`rounded-full border px-4 py-2 text-sm font-medium transition-all focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
                   currentType === option.value
                     ? "border-primary-600 bg-primary-600 text-white"
                     : "border-gray-200 bg-gray-50 text-gray-700 hoverable:hover:border-gray-400 hoverable:hover:bg-white"

--- a/src/components/events/Pagination.tsx
+++ b/src/components/events/Pagination.tsx
@@ -43,7 +43,7 @@ export function Pagination({ filters, currentPage, totalPages }: PaginationProps
       <button
         onClick={() => handlePageChange(currentPage - 1)}
         disabled={currentPage === 1}
-        className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 text-gray-700 transition-all hoverable:hover:border-gray-400 hoverable:hover:bg-white focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-200 disabled:hover:bg-gray-50"
+        className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 text-gray-700 transition-colors hoverable:hover:border-gray-400 hoverable:hover:bg-white focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-200 disabled:hover:bg-gray-50"
         aria-label="前のページへ"
       >
         <svg
@@ -62,7 +62,7 @@ export function Pagination({ filters, currentPage, totalPages }: PaginationProps
         <button
           key={pageNum}
           onClick={() => handlePageChange(pageNum)}
-          className={`flex h-10 min-w-[2.5rem] items-center justify-center rounded-lg border px-3 font-medium transition-all focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
+          className={`flex h-10 min-w-[2.5rem] items-center justify-center rounded-lg border px-3 font-medium transition-colors focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${
             currentPage === pageNum
               ? "border-primary-600 bg-primary-600 text-white"
               : "border-gray-200 bg-gray-50 text-gray-700 hoverable:hover:border-gray-400 hoverable:hover:bg-white"
@@ -78,7 +78,7 @@ export function Pagination({ filters, currentPage, totalPages }: PaginationProps
       <button
         onClick={() => handlePageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
-        className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 text-gray-700 transition-all hoverable:hover:border-gray-400 hoverable:hover:bg-white focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-200 disabled:hover:bg-gray-50"
+        className="flex h-10 w-10 items-center justify-center rounded-lg border border-gray-200 bg-gray-50 text-gray-700 transition-colors hoverable:hover:border-gray-400 hoverable:hover:bg-white focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-gray-200 disabled:hover:bg-gray-50"
         aria-label="次のページへ"
       >
         <svg

--- a/src/components/home/AboutSection.tsx
+++ b/src/components/home/AboutSection.tsx
@@ -240,7 +240,7 @@ export function AboutSection() {
             <Link
               ref={ctaRef}
               href={topSection.cta.href}
-              className="group inline-flex items-center gap-2 rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition-all hover:bg-primary-700 hover:shadow-lg opacity-0"
+              className="group inline-flex items-center gap-2 rounded-full bg-primary-600 px-6 py-3 text-sm font-semibold text-white shadow-md transition-[color,background-color,border-color,box-shadow] hover:bg-primary-700 hover:shadow-lg opacity-0"
             >
               {topSection.cta.label}
               <svg

--- a/src/components/home/NewsSectionInteractive.tsx
+++ b/src/components/home/NewsSectionInteractive.tsx
@@ -312,7 +312,7 @@ export function NewsSectionInteractive({ newsList }: NewsSectionProps) {
               >
                 <Link
                   href="/info"
-                  className="group inline-flex items-center gap-3 rounded-full border-2 border-gray-900 px-8 py-3 font-semibold text-gray-900 transition-all hover:bg-gray-900 hover:text-white"
+                  className="group inline-flex items-center gap-3 rounded-full border-2 border-gray-900 px-8 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-900 hover:text-white"
                 >
                   <span>お知らせ一覧を見る</span>
                   <svg

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -64,6 +64,10 @@ export function Header() {
   return (
     <>
       <header
+        // transition-all はここでは意図的に残している。isAtTop の切り替えで
+        // padding（px/pt）と背景色が同時に変わり、どちらのアニメーションも演出の一部。
+        // #183 D で他の24箇所は変化するプロパティを明示したが、ヘッダーの追従だけは
+        // レイアウトプロパティの補間が本来の目的であり、all が妥当な箇所である。
         className={`sticky top-0 z-40 transition-all duration-300 ${
           isAtTop ? "px-0 pt-0" : "px-4 pt-2"
         }`}
@@ -75,6 +79,9 @@ export function Header() {
         }}
       >
         <div
+          // 同上。ここは border-radius・box-shadow・background-color に加えて
+          // container の max-width と mx-auto の margin まで変化する。
+          // 列挙すると5プロパティになり all との差が無いため、そのままにしてある。
           className={`flex items-center justify-between px-6 py-3 transition-all duration-300 ${
             isAtTop
               ? "rounded-none shadow-none"

--- a/src/components/ui/PageHero.tsx
+++ b/src/components/ui/PageHero.tsx
@@ -86,18 +86,14 @@ export function PageHero({
               <p className="mt-3 text-base text-gray-900/90 lg:mt-4 lg:text-lg">{description}</p>
             )}
             {ctaHref && (
-              <div className="mt-6 flex items-center gap-4 lg:mt-8">
-                <Link
-                  href={ctaHref}
-                  aria-label={ctaLabel}
-                  className="flex h-14 w-14 items-center justify-center rounded-full border border-primary-500 bg-primary-400 text-white transition-colors hover:bg-primary-500 lg:h-16 lg:w-16"
-                >
-                  <ArrowRight className="h-5 w-5 lg:h-6 lg:w-6" />
-                </Link>
+              <Link href={ctaHref} className="group mt-6 inline-flex items-center gap-4 lg:mt-8">
+                <span className="flex h-14 w-14 items-center justify-center rounded-full border border-primary-500 bg-primary-400 text-white transition-colors group-hover:bg-primary-500 lg:h-16 lg:w-16">
+                  <ArrowRight className="h-5 w-5 lg:h-6 lg:w-6" aria-hidden="true" />
+                </span>
                 <span className="text-sm font-semibold uppercase tracking-wider text-gray-900 lg:text-base">
                   {ctaLabel}
                 </span>
-              </div>
+              </Link>
             )}
           </div>
         </div>


### PR DESCRIPTION
#183 の残り4件（B / C / D / E）に対応します。項目 A は #195 で対応済みです。**本PRのマージで #183 は完了します。**

## B. `p-24` が 320px 幅で内容を潰していた

`src/app/error.tsx` と `src/app/not-found.tsx` だけがブレークポイント指定なしの `p-24`（全方向96px）を使っており、320px 幅では内容に 128px しか残りませんでした。**最も動揺している利用者が見る2ページがこれです。**

同リポジトリの `src/app/events/error.tsx` 系は `container mx-auto px-4 py-24` を使っているため、そちらへ揃えました。

実測（320x640 で `/this-page-does-not-exist` を描画）:

| | 修正前 | 修正後 |
| --- | --- | --- |
| 内容幅（h2） | 128px | **288px** |
| 左右 padding | 96px | 16px |
| 横スクロール | なし | なし |

`py-24` と `items-center justify-center` は維持しているため、sm 以上での見た目は変わりません。

## C. `PageHero` の CTA でラベルがリンクの外にあった

矢印だけの円形リンクと、隣接する `<span>` という構造でした。視覚的には1つのボタンに読めるのに、**文字を押しても何も起きません。** `aria-label` があるため支援技術からは正しく見えており、害を受けるのはポインタ利用者だけという見つけにくい欠陥です。

ラベルを `Link` の内側へ入れ、円は `span` へ降格しました。可視テキストがそのままアクセシブル名になるため **`aria-label` は不要になり削除**しています。

### Issue に無かった事実

**`ctaHref` を持つ唯一のエントリ `pageHeroes.about` は、どのページからも参照されていません。** `PageHero` を使う各ページが参照するのは contact / special / guide / privacy / info / faq / events です。つまり CTA は現時点でどの画面にも描画されておらず、Issue の完了条件「`/about` のヒーローで確認」はそのままでは検証できませんでした。

そこで `pageHeroes.info` へ一時的に `ctaHref` を注入して `/info` で実測し、確認後に撤去しています（**一時変更はコミットに含まれていません**）。

```json
{ "href": "/events", "ariaLabel": null, "アクセシブル名": "View More",
  "ラベルはリンク内": true, "ラベル中心を押すとリンクに当たる": true,
  "リンク幅": 178, "ラベル幅": 98, "矢印のariaHidden": "true" }
```

修正前は矢印の 56px だけがリンクで、ラベルの 98px は反応しませんでした。

## D. `transition-all` 24箇所

24箇所すべてについて、同じ `className` 内の `hover:` / `focus-visible:` / `group-hover:` 修飾子を抽出し、**実際に何が変化するかを確定させたうえで**置換しました。一括置換はしていません。

| 変化するもの | 置換後 | 箇所 |
| --- | --- | --- |
| 色のみ | `transition-colors` | 8 |
| 影のみ | `transition-shadow` | 1 |
| 色と影 | `transition-[color,background-color,border-color,box-shadow]` | 13 |
| （据え置き） | `transition-all` のまま | 2 |

### Header.tsx の2箇所は据え置きました

Issue が「個別に確認」としていた箇所です。実際に変化するのは次のとおりで、**レイアウトプロパティの補間こそがこの演出の目的**でした。

- `header` — padding（px/pt）と背景色
- 内側の `div` — border-radius・box-shadow・background-color に加えて、`container` の max-width と `mx-auto` の margin

内側は列挙すると5プロパティになり `transition-all` との差がありません。両方とも据え置き、**理由をコードのコメントへ残しました。** この2箇所を機械的に置換するとスクロール追従の演出が壊れます。

そのため Issue の完了条件「`transition-all` がソースから消えている」は**意図的に満たしていません。** Issue 本文が Header を例外として認めている前提での判断です。

### 副次的にフォーカス表示が速くなります

生成CSSで確認したところ、`transition-colors` は `outline-color` を含みますが `outline-width` は含みません。

```
.transition-colors{transition-property:color,background-color,border-color,outline-color,
text-decoration-color,fill,stroke,--tw-gradient-from,...}
.transition-\[color\,background-color\,border-color\,box-shadow\]{
transition-property:color,background-color,border-color,box-shadow}
.transition-shadow{transition-property:box-shadow}
```

これまでは `transition-all` により `focus-visible:outline-3` の outline-width まで補間されていました。今回それが外れるため、**フォーカス表示は従来より速く出ます。**

## E. グローバルエラーページに回復手段が無かった

見出し「エラーが発生しました」に対し本文が「問題が発生しました」で、同じことを2回言っているだけでした。`events/error.tsx` は正しく書けているため語彙を揃えています。

`text-primary` on `bg-white` のボタンは #176 / #149 の範囲のため触っていません。

## 検査

| 項目 | 結果 |
| --- | --- |
| `pnpm lint` | 0 errors（warning 7件はすべて未変更ファイルの既存分） |
| `pnpm test` | 160 passed |
| `pnpm type-check` | 通過 |
| `pnpm build` | 成功。`assert-events-static-html` も OK |
| 生成CSS | 3種類の `transition-property` を実物で確認 |
| 実ブラウザ | B（320px 幅）と C（当たり判定）を実測 |

## 関連

- #183 — **本PRで A 以外がすべて閉じます**
- #195 — 項目 A（カルーセルの固定ドット）
- #176 / #149 — ボタンのコントラストはこちらの範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESVUJ6KecinXEtLCHW2rrR
