### PR TITLE
REFACTOR: 未使用の pageHeroes.about を削除

### DIFF
--- a/src/data/page-heroes.ts
+++ b/src/data/page-heroes.ts
@@ -60,14 +60,6 @@ export const pageHeroes: Record<string, PageHeroData> = {
     imageSrc: "/images/photos/setagayafe97-image.webp",
     imageAlt: "お知らせイメージ",
   },
-  about: {
-    title: ["世田谷祭", "こころを動かす", "カラクリ"],
-    subtitle: "About Us",
-    ctaHref: "/events",
-    ctaLabel: "View More",
-    imageSrc: "/images/photos/setagayafe97-image.webp",
-    imageAlt: "実行委員会の活動風景",
-  },
   contact: {
     title: "お問い合わせ",
     subtitle: "Contact",


### PR DESCRIPTION
## Summary
- `src/data/page-heroes.ts` の `about` エントリはどこからも参照されておらず、実際の `/about` ページは `AboutHero` コンポーネント（`@/data/about` の `aboutConfig.hero`）を使用する別系統の実装だったため削除
- `grep -rn "pageHeroes.about" src/` で参照ゼロを確認済み

## Test plan
- [x] `pnpm type-check` が通ることを確認
- [x] `pageHeroes.about` への参照が残っていないことを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESVUJ6KecinXEtLCHW2rrR