### PR TITLE
FIX: キーワード検索のクラッシュを修正

### DIFF
--- a/src/lib/events.test.ts
+++ b/src/lib/events.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { normalizeEvent } from "@/lib/events";
+import { filterEvents } from "@/lib/filters";
+import type { RawEvent } from "@/types/events";
+
+/**
+ * `RawEvent` は `title` / `organizer` / `description` / `place` / `building` を
+ * 必須の `string` と宣言しているが、これは型上の約束に過ぎない。microCMS の
+ * フィールドが未入力のまま公開されると、実際には `undefined` が返り得る。
+ *
+ * `title` などを意図的に省いた `Partial<RawEvent>` を `RawEvent` として渡し、
+ * 型の宣言と実データが食い違うケースを再現する。
+ */
+function rawEventFixture(overrides: Partial<RawEvent> = {}): RawEvent {
+  return {
+    id: "ev-1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    date: "day1 : 10月31日（土）",
+    type: "room : 教室企画",
+    place: "1101教室",
+    building: "1号館",
+    title: "テスト企画",
+    organizer: "テスト団体",
+    description: "テスト説明文",
+    content: "",
+    ...overrides,
+  } as RawEvent;
+}
+
+describe("normalizeEvent", () => {
+  it("title/organizer/description/place/building が undefined でも空文字に既定化する", () => {
+    const raw = rawEventFixture({
+      title: undefined,
+      organizer: undefined,
+      description: undefined,
+      place: undefined,
+      building: undefined,
+    } as Partial<RawEvent>);
+
+    const event = normalizeEvent(raw);
+
+    expect(event.title).toBe("");
+    expect(event.organizer).toBe("");
+    expect(event.description).toBe("");
+    expect(event.place).toBe("");
+    expect(event.building).toBe("");
+  });
+
+  it("正規化後の企画をキーワード検索してもクラッシュしない（回帰）", () => {
+    const raw = rawEventFixture({ title: undefined } as Partial<RawEvent>);
+    const events = [normalizeEvent(raw)];
+
+    expect(() => filterEvents(events, { keyword: "テスト" })).not.toThrow();
+  });
+});

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -110,9 +110,17 @@ function normalizeSNSLinks(sns: string | undefined): SNSLinks | undefined {
  * @param rawEvent microCMSから取得した生データ
  * @returns 正規化されたEvent
  */
-function normalizeEvent(rawEvent: RawEvent): Event {
+export function normalizeEvent(rawEvent: RawEvent): Event {
   return {
     ...rawEvent,
+    // microCMS側で必須設定にしていても、入力漏れがあれば undefined が返り得る。
+    // filterEvents 等の内部コードがこれらを常に string だと信頼できるよう、
+    // 外部データの境界であるここで一度だけ空文字へ既定化する。
+    title: rawEvent.title ?? "",
+    organizer: rawEvent.organizer ?? "",
+    description: rawEvent.description ?? "",
+    place: rawEvent.place ?? "",
+    building: rawEvent.building ?? "",
     date: normalizeEventDate(rawEvent.date),
     type: normalizeEventType(rawEvent.type),
     sns: typeof rawEvent.sns === "string" ? normalizeSNSLinks(rawEvent.sns) : undefined,


### PR DESCRIPTION
## Summary
- `/events` でキーワードを1文字でも入力すると、`title`/`organizer`/`description`/`place`/`building` が `undefined` になり得るのに `filterEvents` が無条件で `.toLowerCase()` を呼んでいたためクラッシュしていた（再試行も同じ入力で再クラッシュし復旧不能）
- `RawEvent` はこれらを必須 `string` と宣言しているが、microCMS 側の入力漏れで実際には `undefined` が返り得る。外部データの境界である `normalizeEvent`（`src/lib/events.ts`）で空文字へ既定化し、内部コードが型の保証をそのまま信頼できるようにした
- 回帰防止のユニットテスト（`src/lib/events.test.ts`）を新規追加

## Test plan
- [x] `pnpm test`（新規テスト含め162件通過）
- [x] `pnpm lint` / `pnpm type-check`
- [x] `pnpm build` + `scripts/assert-events-static-html.mjs`
- [x] 実機ブラウザで `/events` のキーワード欄に入力し、クラッシュしないこと・正しく絞り込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)