### PR TITLE
FIX: 開催日・企画種別フィルターにグループのセマンティクスを付与

### DIFF
--- a/src/components/events/EventFilters.tsx
+++ b/src/components/events/EventFilters.tsx
@@ -58,8 +58,10 @@ export function EventFilters({ filters }: EventFiltersProps) {
 
       <div className="space-y-6">
         {/* 日程フィルター */}
-        <div>
-          <label className="mb-2 block text-sm font-semibold text-gray-900/90">開催日</label>
+        <fieldset className="m-0 min-w-0 border-0 p-0">
+          <legend className="m-0 mb-2 block p-0 text-sm font-semibold text-gray-900/90">
+            開催日
+          </legend>
           <div className="flex flex-wrap gap-2">
             {dateFilterOptions.map((option) => (
               <button
@@ -76,11 +78,13 @@ export function EventFilters({ filters }: EventFiltersProps) {
               </button>
             ))}
           </div>
-        </div>
+        </fieldset>
 
         {/* 企画種別フィルター */}
-        <div>
-          <label className="mb-2 block text-sm font-semibold text-gray-900/90">企画種別</label>
+        <fieldset className="m-0 min-w-0 border-0 p-0">
+          <legend className="m-0 mb-2 block p-0 text-sm font-semibold text-gray-900/90">
+            企画種別
+          </legend>
           <div className="flex flex-wrap gap-2">
             {typeFilterOptions.map((option) => (
               <button
@@ -97,7 +101,7 @@ export function EventFilters({ filters }: EventFiltersProps) {
               </button>
             ))}
           </div>
-        </div>
+        </fieldset>
 
         {/* 建物フィルター */}
         <div>


### PR DESCRIPTION
## Summary
- `EventFilters` の開催日・企画種別フィルターは `aria-pressed` の疑似トグルボタン列だが、実際は排他選択（ラジオ的な挙動）。グループ化・ラベル付けが無く、両グループが同じ「すべて」ラベルを持つため、スクリーンリーダー利用者には文脈が曖昧だった
- `<div>` + `<label>` を `<fieldset>` + `<legend>` に変更し、グループ名を明示した。`aria-pressed`・クリック処理・見た目は変更していない
- `role="radiogroup"`ではなく`fieldset`/`legend`を選んだ理由: ARIAのradio化にはロービングtabindexなど矢印キー操作の実装が伴って初めて正しい挙動になる。それを伴わずrole="radio"だけ付けると現状より悪い体験になるため、最小の変更で正しく直せるこちらを採用した

## Test plan
- [x] `pnpm test` / `pnpm lint` / `pnpm type-check`
- [x] `pnpm build` + `scripts/assert-events-static-html.mjs`（このファイルはSuspense fallbackツリーの一部）
- [x] Chrome DevToolsのアクセシビリティパネルで両グループが名前付きグループとして読み上げられることを確認
- [x] 実機ブラウザでフィルター操作に回帰がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)