### PR TITLE
FIX: 結果件数の変化を通知しグレー系トークンを統一

### DIFF
--- a/src/components/events/EventGrid.tsx
+++ b/src/components/events/EventGrid.tsx
@@ -29,8 +29,8 @@ export function EventGrid({ events, variant = "default" }: EventGridProps) {
             d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
           />
         </svg>
-        <p className="text-lg font-semibold text-gray-900/80">該当する企画が見つかりませんでした</p>
-        <p className="mt-2 text-sm text-gray-900/60">フィルター条件を変更してお試しください</p>
+        <p className="text-lg font-semibold text-gray-700">該当する企画が見つかりませんでした</p>
+        <p className="mt-2 text-sm text-gray-600">フィルター条件を変更してお試しください</p>
       </div>
     );
   }

--- a/src/components/events/EventsView.tsx
+++ b/src/components/events/EventsView.tsx
@@ -46,7 +46,7 @@ export function EventsView({
         <main>
           {/* 検索結果件数 */}
           <div className="mb-6 flex items-center justify-between">
-            <p className="text-sm text-gray-900/80">
+            <p className="text-sm text-gray-700" role="status" aria-live="polite">
               <span className="font-semibold text-gray-900">{totalCount}</span>{" "}
               件の企画が見つかりました
             </p>


### PR DESCRIPTION
## Summary
- `EventsView` の検索結果件数テキストに `role="status" aria-live="polite"` を追加し、フィルター変更による件数更新がスクリーンリーダーに伝わるようにした（フックを使わない静的な変更のためSuspense fallback制約に抵触しない）
- あわせて `EventsView` / `EventGrid` の `text-gray-900/80`・`/60` という場当たり的な不透明度指定を、プロジェクトの離散グレースケール（`gray-700` / `gray-600`）に統一した

## Test plan
- [x] `pnpm test` / `pnpm lint` / `pnpm type-check`
- [x] `pnpm build` + `scripts/assert-events-static-html.mjs`
- [x] VoiceOverでフィルターを変更し、新しい件数が読み上げられることを確認
- [x] 白背景上でのコントラストを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)