### PR TITLE
FIX: 企画カードのフォーカスリングと画像sizesを是正

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -34,7 +34,10 @@ export function EventCard({ event, variant = "default" }: EventCardProps) {
   const venue = [event.building, event.place].filter(Boolean).join(" ") || "会場未定";
 
   return (
-    <Link href={href} className="group block h-full">
+    <Link
+      href={href}
+      className={`group block h-full focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600 ${isCompact ? "rounded-lg" : "rounded-xl"}`}
+    >
       <article
         className={`h-full overflow-hidden border border-gray-200 bg-white transition-[border-color,box-shadow] hover:border-primary-300 hover:shadow-sm ${isCompact ? "flex items-start rounded-lg" : "rounded-xl"}`}
       >

--- a/src/components/ui/CircleImage.tsx
+++ b/src/components/ui/CircleImage.tsx
@@ -18,9 +18,18 @@ export function CircleImage({ src, alt, size = "md" }: CircleImageProps) {
     xl: "h-40 w-40",
   };
 
+  // レスポンシブ可変を持たない固定pxのボックスなので、ブレークポイント無しの
+  // 単一値で十分。ボックスの実測px（Tailwindのスペーシングスケール由来）と揃える。
+  const sizePx = {
+    sm: 64,
+    md: 96,
+    lg: 128,
+    xl: 160,
+  };
+
   return (
     <div className={`relative overflow-hidden rounded-full ${sizeClasses[size]}`}>
-      <Image src={src} alt={alt} fill className="object-cover" />
+      <Image src={src} alt={alt} fill sizes={`${sizePx[size]}px`} className="object-cover" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `EventCard` の `<Link>` に `focus-visible` の指定が無く、キーボードフォーカス時だけブラウザ既定の青いアウトラインになっていた（フィルター・ページネーション等は一貫して紫トークン）。プロジェクト共通のフォーカスリングトークンを追加した
- `CircleImage` の `<Image fill>` に `sizes` が無くコンソール警告がカード毎に出ていた。サムネイルは固定pxのボックス（sm/md/lg/xl）のため、対応する固定px値を`sizes`として渡すようにした

## Test plan
- [x] `pnpm test` / `pnpm lint` / `pnpm type-check`
- [x] 実機ブラウザでキーボードフォーカス時の色を確認、コンソール警告が消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)