### PR TITLE
STYLE: 企画一覧グリッドにxl:grid-cols-4を追加

### DIFF
--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -44,7 +44,10 @@ export function EventCard({ event, variant = "default" }: EventCardProps) {
             <CircleImage
               src={event.thumbnail.url}
               alt={event.title}
-              size={isCompact ? "md" : "xl"}
+              // xl(160px)だと、xl:グリッドの4カラム時にカード幅(約195px)から
+              // p-6の余白(48px)を引いた残り(約147px)より大きく、
+              // flexが円を横方向だけ縮めて楕円になる。lg(128px)なら収まる。
+              size={isCompact ? "md" : "lg"}
             />
           </div>
         )}

--- a/src/components/events/EventGrid.tsx
+++ b/src/components/events/EventGrid.tsx
@@ -35,10 +35,15 @@ export function EventGrid({ events, variant = "default" }: EventGridProps) {
     );
   }
 
+  // compact（関連企画等、常に3件固定）には xl 列を増やさない。
+  // 3件しかない行にカラムだけ増やすと、4本目のトラックが空のまま伸びてしまう。
+  const gridColsClassName =
+    variant === "compact"
+      ? "grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      : "grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+
   return (
-    <div
-      className={`grid ${variant === "compact" ? "gap-4" : "gap-6"} sm:grid-cols-2 lg:grid-cols-3`}
-    >
+    <div className={gridColsClassName}>
       {events.map((event) => (
         <EventCard key={event.id} event={event} variant={variant} />
       ))}


### PR DESCRIPTION
## Summary
- `lg:grid-cols-3` が上限で `xl:`/`2xl:` が無く、`max-w-7xl` の枠内でも広い画面でカードが間延びしていた。`variant !== "compact"` の場合のみ `xl:grid-cols-4` を追加した（`RelatedEvents` が使う compact 表示は常に3件固定のため対象外）
- 4カラム時のカード幅（実測・計算とも約195px）は、デフォルトの円形サムネイル(xl=160px)+左右パディング(48px)の必要幅208pxより狭く、flexが円を横方向だけ縮めて楕円になることを実測で確認した。デフォルト時のサムネイルサイズを xl → lg(128px) に縮小し、実測で歪みが無いことを確認済み

## Test plan
- [x] `pnpm test` / `pnpm lint` / `pnpm type-check`
- [x] 実機ブラウザで、実際の4カラム幅（main列852px、gap-6、card幅195px）を再現してサムネイルの歪みが無いことを実測確認
- [x] `/events/[id]` の関連企画（3件・compact表示）が崩れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)