### PR TITLE
STYLE: loading/errorのシェルを実ページと統一

### DIFF
--- a/src/app/events/error.tsx
+++ b/src/app/events/error.tsx
@@ -3,9 +3,16 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
 
 /**
  * 企画一覧ページのエラーページ
+ *
+ * 本体（`page.tsx`）と同じ `PageSheetLayout` を使う。以前は濃紫グラデーションの
+ * ヘッダーを個別に手書きしており、本体の白いシートへ切り替わる瞬間に見た目が
+ * 飛んでいた上、その濃色背景に text-gray-900 を直置きしていたためコントラストも
+ * 不足していた。白いシートへ揃えることでどちらも解消する。
  */
 export default function EventsError({
   error,
@@ -19,18 +26,7 @@ export default function EventsError({
   }, [error]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-primary-dark to-primary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <h1 className="mb-4 text-center text-4xl font-bold md:text-5xl">企画を探す</h1>
-          <p className="text-center text-lg opacity-90">
-            第97回 世田谷祭の企画を検索・閲覧できます
-          </p>
-        </div>
-      </div>
-
-      {/* エラーメッセージ */}
+    <PageSheetLayout hero={pageHeroes.events}>
       <div className="container mx-auto px-4 py-24">
         <div className="mx-auto max-w-md text-center">
           <svg
@@ -48,22 +44,26 @@ export default function EventsError({
             />
           </svg>
           <h2 className="mb-4 text-2xl font-bold text-gray-900">エラーが発生しました</h2>
-          <p className="mb-8 text-gray-900/80">
+          <p className="mb-8 text-gray-700">
             企画一覧の読み込み中にエラーが発生しました。しばらく経ってから再度お試しください。
           </p>
           <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
-            <Button onClick={reset} variant="primary">
+            <Button
+              onClick={reset}
+              variant="primary"
+              className="bg-primary-600 text-white hoverable:hover:bg-primary-700"
+            >
               再試行
             </Button>
             <Link
               href="/"
-              className="inline-flex items-center justify-center rounded-lg bg-white/10 px-6 py-3 text-base font-semibold text-gray-900 shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hover:bg-white/20 hover:shadow-lg focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-white"
+              className="inline-flex items-center justify-center rounded-lg border border-gray-200 bg-gray-50 px-6 py-3 text-base font-semibold text-gray-700 shadow-md transition-[color,background-color,border-color,box-shadow] duration-200 hoverable:hover:border-gray-400 hoverable:hover:bg-white focus-visible:outline-3 focus-visible:outline-offset-3 focus-visible:outline-primary-600"
             >
               トップページへ戻る
             </Link>
           </div>
         </div>
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }

--- a/src/app/events/loading.tsx
+++ b/src/app/events/loading.tsx
@@ -1,57 +1,54 @@
+import { PageSheetLayout } from "@/components/layout/PageSheetLayout";
+import { pageHeroes } from "@/data/page-heroes";
+
 /**
  * 企画一覧ページのローディングUI
+ *
+ * 本体（`page.tsx`）と同じ `PageSheetLayout` を使う。以前は濃紫グラデーションの
+ * ヘッダーを個別に手書きしており、本体の白いシートへ切り替わる瞬間に見た目が
+ * 飛んでいた。骨格を共有コンポーネントへ揃えることでこの不整合を無くす。
  */
 export default function EventsLoading() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-primary-dark to-primary">
-      {/* ページヘッダー */}
-      <div className="bg-secondary py-16 text-gray-900">
-        <div className="container mx-auto px-4">
-          <h1 className="mb-4 text-center text-4xl font-bold md:text-5xl">企画を探す</h1>
-          <p className="text-center text-lg opacity-90">
-            第97回 世田谷祭の企画を検索・閲覧できます
-          </p>
-        </div>
-      </div>
-
-      {/* コンテンツ */}
-      <div className="container mx-auto px-4 py-12">
+    <PageSheetLayout hero={pageHeroes.events}>
+      <div className="container mx-auto px-4 py-12" role="status" aria-live="polite">
+        <span className="sr-only">企画を読み込んでいます</span>
         <div className="lg:grid lg:grid-cols-[300px_1fr] lg:gap-8">
           {/* サイドバー: フィルタースケルトン */}
           <aside className="mb-8 lg:mb-0">
-            <div className="rounded-lg border border-gray-200/20 bg-white/10 p-6 shadow-sm">
+            <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
               <div className="mb-4 flex items-center justify-between">
-                <div className="h-6 w-24 animate-pulse rounded bg-white/15" />
-                <div className="h-4 w-16 animate-pulse rounded bg-white/15" />
+                <div className="h-6 w-24 animate-pulse rounded bg-gray-200" />
+                <div className="h-4 w-16 animate-pulse rounded bg-gray-200" />
               </div>
               <div className="space-y-6">
                 {/* 日程フィルタースケルトン */}
                 <div>
-                  <div className="mb-2 h-5 w-16 animate-pulse rounded bg-white/15" />
+                  <div className="mb-2 h-5 w-16 animate-pulse rounded bg-gray-200" />
                   <div className="flex flex-wrap gap-2">
                     {[1, 2, 3, 4].map((i) => (
-                      <div key={i} className="h-10 w-20 animate-pulse rounded-full bg-white/15" />
+                      <div key={i} className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
                     ))}
                   </div>
                 </div>
                 {/* 企画種別フィルタースケルトン */}
                 <div>
-                  <div className="mb-2 h-5 w-20 animate-pulse rounded bg-white/15" />
+                  <div className="mb-2 h-5 w-20 animate-pulse rounded bg-gray-200" />
                   <div className="flex flex-wrap gap-2">
                     {[1, 2, 3, 4].map((i) => (
-                      <div key={i} className="h-10 w-24 animate-pulse rounded-full bg-white/15" />
+                      <div key={i} className="h-10 w-24 animate-pulse rounded-full bg-gray-200" />
                     ))}
                   </div>
                 </div>
                 {/* 建物フィルタースケルトン */}
                 <div>
-                  <div className="mb-2 h-5 w-12 animate-pulse rounded bg-white/15" />
-                  <div className="h-10 w-full animate-pulse rounded-lg bg-white/15" />
+                  <div className="mb-2 h-5 w-12 animate-pulse rounded bg-gray-200" />
+                  <div className="h-10 w-full animate-pulse rounded-lg bg-gray-200" />
                 </div>
                 {/* キーワード検索スケルトン */}
                 <div>
-                  <div className="mb-2 h-5 w-32 animate-pulse rounded bg-white/15" />
-                  <div className="h-10 w-full animate-pulse rounded-lg bg-white/15" />
+                  <div className="mb-2 h-5 w-32 animate-pulse rounded bg-gray-200" />
+                  <div className="h-10 w-full animate-pulse rounded-lg bg-gray-200" />
                 </div>
               </div>
             </div>
@@ -60,33 +57,33 @@ export default function EventsLoading() {
           {/* メインコンテンツ */}
           <main>
             {/* 検索結果件数スケルトン */}
-            <div className="mb-6 h-5 w-48 animate-pulse rounded bg-white/15" />
+            <div className="mb-6 h-5 w-48 animate-pulse rounded bg-gray-200" />
 
             {/* 企画グリッドスケルトン */}
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {[1, 2, 3, 4, 5, 6].map((i) => (
                 <div
                   key={i}
-                  className="overflow-hidden rounded-lg border border-gray-200/20 bg-white/10 shadow-sm"
+                  className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
                 >
                   {/* サムネイルスケルトン */}
-                  <div className="aspect-video w-full animate-pulse bg-white/15" />
+                  <div className="aspect-video w-full animate-pulse bg-gray-200" />
                   {/* コンテンツスケルトン */}
                   <div className="p-6">
                     <div className="mb-3 flex gap-2">
-                      <div className="h-6 w-16 animate-pulse rounded-full bg-white/15" />
-                      <div className="h-6 w-20 animate-pulse rounded-full bg-white/15" />
+                      <div className="h-6 w-16 animate-pulse rounded-full bg-gray-200" />
+                      <div className="h-6 w-20 animate-pulse rounded-full bg-gray-200" />
                     </div>
-                    <div className="mb-2 h-6 w-3/4 animate-pulse rounded bg-white/15" />
-                    <div className="mb-3 h-5 w-1/2 animate-pulse rounded bg-white/15" />
+                    <div className="mb-2 h-6 w-3/4 animate-pulse rounded bg-gray-200" />
+                    <div className="mb-3 h-5 w-1/2 animate-pulse rounded bg-gray-200" />
                     <div className="mb-4 space-y-2">
-                      <div className="h-4 w-full animate-pulse rounded bg-white/15" />
-                      <div className="h-4 w-full animate-pulse rounded bg-white/15" />
-                      <div className="h-4 w-3/4 animate-pulse rounded bg-white/15" />
+                      <div className="h-4 w-full animate-pulse rounded bg-gray-200" />
+                      <div className="h-4 w-full animate-pulse rounded bg-gray-200" />
+                      <div className="h-4 w-3/4 animate-pulse rounded bg-gray-200" />
                     </div>
-                    <div className="flex gap-4 border-t pt-3">
-                      <div className="h-4 w-24 animate-pulse rounded bg-white/15" />
-                      <div className="h-4 w-28 animate-pulse rounded bg-white/15" />
+                    <div className="flex gap-4 border-t border-gray-200 pt-3">
+                      <div className="h-4 w-24 animate-pulse rounded bg-gray-200" />
+                      <div className="h-4 w-28 animate-pulse rounded bg-gray-200" />
                     </div>
                   </div>
                 </div>
@@ -95,6 +92,6 @@ export default function EventsLoading() {
           </main>
         </div>
       </div>
-    </div>
+    </PageSheetLayout>
   );
 }


### PR DESCRIPTION
## Summary
- `/events` の `loading.tsx`・`error.tsx` が本体（`PageSheetLayout` + `PageHero` の白いシート）と全く異なる濃紫グラデーションのヘッダーを個別に手書きしており、ナビゲーション毎・エラー毎に見た目が飛んでいた
- `PageSheetLayout` + `pageHeroes.events` を直接importして共有シェルに統一した（`/events/[id]/loading.tsx` が既に採用している配色規約 `bg-gray-200` にも合わせた）
- `error.tsx` は白いシートになったことで、濃色背景直置きだった `text-gray-900` の低コントラストが解消される。再試行ボタン（`variant="primary"`＝`bg-white text-primary`、濃色背景前提の配色）は白背景では視認できなくなるため、選択中フィルターピル/ページネーションと同じ配色（`bg-primary-600 text-white`）を明示的に上書きした。「トップページへ戻る」も未選択フィルターと同じ配色に変更した

## Test plan
- [x] `pnpm test` / `pnpm lint` / `pnpm type-check`
- [x] `pnpm build` + `scripts/assert-events-static-html.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)